### PR TITLE
chore(package.json): update vscode engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "main": "./dist/extension",
   "engines": {
-    "vscode": "^1.47.0"
+    "vscode": "^1.53.0"
   },
   "categories": [
     "Other",


### PR DESCRIPTION
Close #101 

Checked and confirmed `vsce package` is now working:

```bash
$ vsce package
Executing prepublish script 'npm run vscode:prepublish'...

> terminal-all-in-one@1.11.16 vscode:prepublish C:\terminal-all-in-one
runtime modules 211 bytes 2 modules
modules by path ./node_modules/moment/locale/*.js 499 KiB 135 modules
modules by path ./src/ 105 KiB
  modules by path ./src/commands/ 22.9 KiB 13 modules
  modules by path ./src/helpers/*.ts 1.76 KiB 3 modules
  modules by path ./src/*.ts 9.63 KiB
    ./src/extension.ts 2.23 KiB [built] [code generated]
    ./src/messages.ts 7.4 KiB [built] [code generated]
  ./src/themes.json 70.7 KiB [built] [code generated]
external "vscode" 42 bytes [built] [code generated]
./node_modules/moment/moment.js 170 KiB [built] [code generated]
./node_modules/moment/locale/ sync ^\.\/.*$ 3.21 KiB [optional] [built] [code generated]
./node_modules/lodash.debounce/index.js 10.5 KiB [built] [code generated]
webpack 5.21.2 compiled successfully in 9010 ms
 DONE  Packaged: C:\terminal-all-in-one\terminal-all-in-one-1.11.16.vsix (26 files, 12.41MB)
```