### PR TITLE
Add conductor.json with Conductor workspace scripts (#436)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,10 @@ You'll need [Node.js](https://nodejs.org/) and [VS Code](https://code.visualstud
    pnpm run lint
    ```
 
+### Running in Conductor
+
+[Conductor](https://conductor.build/) reads `conductor.json` to set up each workspace, then clicking **Run** builds the extension and opens an isolated Extension Development Host with it loaded, watching for changes. This requires the `code` CLI on your PATH (in VS Code: **Shell Command: Install 'code' command in PATH**). After editing, reload the dev host with **Cmd+R** to pick up the rebuilt extension.
+
 ## Reporting Bugs & Requesting Features
 
 Search [existing issues](https://github.com/YashTotale/terminal-all-in-one/issues) first. If nothing matches, open a [new issue](https://github.com/YashTotale/terminal-all-in-one/issues/new/choose) and include:

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "setup": "pnpm install",
+    "run": "pnpm run build:dev && code --new-window --disable-extensions --extensionDevelopmentPath=\"$PWD\" --user-data-dir=\"${TMPDIR:-/tmp}/conductor-vscode/${PWD##*/}\" \"$PWD\" && pnpm run watch",
+    "archive": "rm -rf \"${TMPDIR:-/tmp}/conductor-vscode/${PWD##*/}\""
+  },
+  "runScriptMode": "concurrent"
+}

--- a/conductor.json
+++ b/conductor.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
     "setup": "pnpm install",
-    "run": "pnpm run build:dev && code --new-window --disable-extensions --extensionDevelopmentPath=\"$PWD\" --user-data-dir=\"${TMPDIR:-/tmp}/conductor-vscode/${PWD##*/}\" \"$PWD\" && pnpm run watch",
-    "archive": "rm -rf \"${TMPDIR:-/tmp}/conductor-vscode/${PWD##*/}\""
+    "run": "pnpm run build:dev && code --new-window --disable-extensions --extensionDevelopmentPath=\"$PWD\" --user-data-dir=\"${TMPDIR:-/tmp}/conductor-vscode/${CONDUCTOR_WORKSPACE_NAME}\" \"$PWD\" && pnpm run watch",
+    "archive": "rm -rf \"${TMPDIR:-/tmp}/conductor-vscode/${CONDUCTOR_WORKSPACE_NAME}\""
   },
   "runScriptMode": "concurrent"
 }


### PR DESCRIPTION
Adds a repo-root `conductor.json` so Conductor's setup/run/archive scripts are shared across the team (closes #436). The `run` script builds the extension and opens an isolated Extension Development Host with a per-workspace `--user-data-dir` under `$TMPDIR`, and `runScriptMode: "concurrent"` lets multiple workspaces run at once without clobbering each other's global settings or writing into the worktree. `archive` removes that temp dir on cleanup, and CONTRIBUTING.md documents the flow (requires the `code` CLI on PATH; Cmd+R to reload the dev host after edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced contributor documentation with instructions for running the extension in development mode using Conductor, including environment setup, watch mode, and necessary prerequisites.

* **Chores**
  * Added development environment configuration to automate setup, execution, and cleanup workflows for development instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->