### PR TITLE
Polish README Contributing section and trim CONTRIBUTING intro

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Terminal All In One
 
-Thanks for your interest in contributing! This guide covers local development, reporting issues, and asking questions.
+Thanks for your interest in contributing!
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ Scripts support [VS Code variables](https://code.visualstudio.com/docs/editor/va
 
 ## Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for local development setup. To report a bug or request a feature, open an [issue](https://github.com/YashTotale/terminal-all-in-one/issues/new/choose); for usage questions, start a thread in [Discussions](https://github.com/YashTotale/terminal-all-in-one/discussions/categories/q-a).
+Contributions are welcome! See [CONTRIBUTING.md](https://github.com/YashTotale/terminal-all-in-one?tab=contributing-ov-file#readme) for local development setup. To report a bug or request a feature, open an [issue](https://github.com/YashTotale/terminal-all-in-one/issues/new/choose); for usage questions, start a thread in [Discussions](https://github.com/YashTotale/terminal-all-in-one/discussions/categories/q-a).
 
-Licensed under [MIT](LICENSE).
+Licensed under [MIT](https://github.com/YashTotale/terminal-all-in-one?tab=MIT-1-ov-file#readme).


### PR DESCRIPTION
Update the README's Contributing section so the **CONTRIBUTING.md** and **MIT** links point at GitHub's overview tabs (`?tab=contributing-ov-file` / `?tab=MIT-1-ov-file`), matching the link style used in goodreads-user-scraper; the surrounding prose already matched word-for-word. Also trim the CONTRIBUTING.md intro from two sentences to a single "Thanks for your interest in contributing!" line.

## Test Plan
- [ ] Docs-only change — verified both GitHub tab URLs return HTTP 200