### PR TITLE
Expand test coverage: commands, startup, messages, manifest parity (#441)

### DIFF
--- a/src/commands/chooseTerminalTheme.ts
+++ b/src/commands/chooseTerminalTheme.ts
@@ -67,7 +67,7 @@ export function onTerminalThemeChange(event: ConfigurationChangeEvent) {
 }
 
 // Merge the theme's terminal colors onto the user's existing colorCustomizations, written at that setting's real scope. "None" strips terminal colors.
-function applyTheme(themeName: string) {
+export function applyTheme(themeName: string) {
   const themeIndex = themes.findIndex((t: theme) => t.name === themeName);
   if (themeIndex === -1) {
     return showThemeDoesNotExist();

--- a/src/commands/runScript.ts
+++ b/src/commands/runScript.ts
@@ -55,7 +55,7 @@ export function execute({ name, script }: ScriptObject) {
   });
 }
 
-function getScriptsConfig(): ScriptObject[] {
+export function getScriptsConfig(): ScriptObject[] {
   const scripts = getConfig({ config: EXTENSION_NAME, section: "scripts" });
   if (!Array.isArray(scripts)) return [];
   return scripts.filter(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,14 +24,14 @@ function createCommands(context: ExtensionContext) {
   });
 }
 
-function onFirstActivate(context: ExtensionContext) {
+export function onFirstActivate(context: ExtensionContext) {
   if (!context.globalState.get(stateProps.LAST_FOLLOW_UP)) {
     showWelcome();
     context.globalState.update(stateProps.LAST_FOLLOW_UP, Date.now());
   }
 }
 
-function timeSinceInstall(context: ExtensionContext) {
+export function timeSinceInstall(context: ExtensionContext) {
   const stored = context.globalState.get(stateProps.LAST_FOLLOW_UP);
   if (stored === undefined) return;
   if (context.globalState.get(stateProps.SHOULD_NOT_SHOW_FOLLOW_UP)) return;

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -9,7 +9,7 @@ import {
 
 const DONT_SHOW = "Don't Show Again";
 
-function messagesEnabled() {
+export function messagesEnabled() {
   return !getConfig({ section: `${EXTENSION_NAME}.disableAllMessages` });
 }
 

--- a/src/test/suite/changeFontWeight.test.ts
+++ b/src/test/suite/changeFontWeight.test.ts
@@ -1,0 +1,52 @@
+import assert from "assert";
+import { window, workspace, ConfigurationTarget } from "vscode";
+import { changeFontWeight } from "../../commands/changeFontWeight";
+
+const SECTION = "terminal.integrated.fontWeight";
+
+suite("changeFontWeight", () => {
+  const realShowQuickPick = window.showQuickPick;
+  let original: string | undefined;
+
+  suiteSetup(() => {
+    original = workspace.getConfiguration().inspect(SECTION)?.globalValue as
+      | string
+      | undefined;
+  });
+
+  suiteTeardown(async () => {
+    (window as { showQuickPick: any }).showQuickPick = realShowQuickPick;
+    await workspace
+      .getConfiguration()
+      .update(SECTION, original, ConfigurationTarget.Global);
+  });
+
+  test("persists the picked weight", async () => {
+    await workspace
+      .getConfiguration()
+      .update(SECTION, "normal", ConfigurationTarget.Global);
+    (window as { showQuickPick: any }).showQuickPick = async (items: any[]) =>
+      items.find((i) => i.label === "bold");
+    await changeFontWeight();
+    assert.strictEqual(workspace.getConfiguration().get(SECTION), "bold");
+  });
+
+  test("persists a numeric weight string", async () => {
+    await workspace
+      .getConfiguration()
+      .update(SECTION, "normal", ConfigurationTarget.Global);
+    (window as { showQuickPick: any }).showQuickPick = async (items: any[]) =>
+      items.find((i) => i.label === "300");
+    await changeFontWeight();
+    assert.strictEqual(workspace.getConfiguration().get(SECTION), "300");
+  });
+
+  test("restores on cancel", async () => {
+    await workspace
+      .getConfiguration()
+      .update(SECTION, "bold", ConfigurationTarget.Global);
+    (window as { showQuickPick: any }).showQuickPick = async () => undefined;
+    await changeFontWeight();
+    assert.strictEqual(workspace.getConfiguration().get(SECTION), "bold");
+  });
+});

--- a/src/test/suite/chooseTerminalTheme.test.ts
+++ b/src/test/suite/chooseTerminalTheme.test.ts
@@ -1,0 +1,117 @@
+import assert from "assert";
+import { window, workspace, ConfigurationTarget } from "vscode";
+import {
+  applyTheme,
+  onTerminalThemeChange,
+  chooseTerminalTheme,
+} from "../../commands/chooseTerminalTheme";
+import themes from "../../themes.json";
+
+const COLORS = "workbench.colorCustomizations";
+const THEME = "terminalAllInOne.terminalTheme";
+const sample = themes[0];
+
+function colorsValue() {
+  return workspace.getConfiguration().inspect(COLORS)?.globalValue as
+    | Record<string, string>
+    | undefined;
+}
+async function setColors(value: Record<string, string> | undefined) {
+  await workspace
+    .getConfiguration()
+    .update(COLORS, value, ConfigurationTarget.Global);
+}
+const tick = () => new Promise((r) => setTimeout(r, 100));
+
+suite("chooseTerminalTheme", () => {
+  const realShowQuickPick = window.showQuickPick;
+  const realShowErrorMessage = window.showErrorMessage;
+  let originalColors: Record<string, string> | undefined;
+  let originalTheme: string | undefined;
+
+  suiteSetup(() => {
+    originalColors = colorsValue();
+    originalTheme = workspace.getConfiguration().inspect(THEME)?.globalValue as
+      | string
+      | undefined;
+  });
+
+  suiteTeardown(async () => {
+    (window as { showQuickPick: any }).showQuickPick = realShowQuickPick;
+    (window as { showErrorMessage: any }).showErrorMessage =
+      realShowErrorMessage;
+    await setColors(originalColors);
+    await workspace
+      .getConfiguration()
+      .update(THEME, originalTheme, ConfigurationTarget.Global);
+  });
+
+  test("applyTheme merges the theme's colors onto existing customizations", async () => {
+    await setColors({ "editor.background": "#123456" });
+    await applyTheme(sample.name);
+    assert.deepStrictEqual(colorsValue(), {
+      "editor.background": "#123456",
+      ...sample.colors,
+    });
+  });
+
+  test("applyTheme('None') strips terminal colors, keeping the rest", async () => {
+    await setColors({
+      "editor.background": "#123456",
+      "terminal.background": "#000000",
+      "terminalCursor.foreground": "#ffffff",
+    });
+    await applyTheme("None");
+    assert.deepStrictEqual(colorsValue(), { "editor.background": "#123456" });
+  });
+
+  test("applyTheme on an unknown theme errors and writes nothing", async () => {
+    await setColors({ "editor.background": "#123456" });
+    let shown = false;
+    (window as { showErrorMessage: any }).showErrorMessage = () => {
+      shown = true;
+      return Promise.resolve(undefined);
+    };
+    await applyTheme("Definitely Not A Real Theme");
+    assert.ok(shown, "expected the theme-does-not-exist error");
+    assert.deepStrictEqual(colorsValue(), { "editor.background": "#123456" });
+  });
+
+  test("onTerminalThemeChange applies the saved theme only when affected", async () => {
+    await workspace
+      .getConfiguration()
+      .update(THEME, sample.name, ConfigurationTarget.Global);
+    await tick();
+    await setColors({});
+    onTerminalThemeChange({
+      affectsConfiguration: (s: string) => s === THEME,
+    } as any);
+    await tick();
+    assert.deepStrictEqual(colorsValue(), { ...sample.colors });
+
+    await setColors({ "editor.background": "#123456" });
+    onTerminalThemeChange({ affectsConfiguration: () => false } as any);
+    await tick();
+    assert.deepStrictEqual(colorsValue(), { "editor.background": "#123456" });
+  });
+
+  test("the picker persists the chosen theme name on accept", async () => {
+    await workspace
+      .getConfiguration()
+      .update(THEME, "None", ConfigurationTarget.Global);
+    (window as { showQuickPick: any }).showQuickPick = async () => ({
+      label: sample.name,
+    });
+    await chooseTerminalTheme();
+    // chooseTerminalTheme persists the theme name without awaiting the write.
+    await tick();
+    assert.strictEqual(workspace.getConfiguration().get(THEME), sample.name);
+  });
+
+  test("the picker restores colorCustomizations on cancel", async () => {
+    await setColors({ "editor.background": "#abcabc" });
+    (window as { showQuickPick: any }).showQuickPick = async () => undefined;
+    await chooseTerminalTheme();
+    assert.deepStrictEqual(colorsValue(), { "editor.background": "#abcabc" });
+  });
+});

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -1,0 +1,75 @@
+import assert from "assert";
+import { commands, extensions } from "vscode";
+import {
+  EXTENSION_NAME,
+  EXTENSION_NAME_W_PUBLISHER,
+} from "../../helpers/constants";
+import commandList from "../../commands";
+
+suite("manifest ↔ registration parity", () => {
+  const extension = extensions.getExtension(EXTENSION_NAME_W_PUBLISHER);
+  let manifest: any;
+  let registered: string[];
+
+  suiteSetup(async () => {
+    await extension?.activate();
+    manifest = extension?.packageJSON;
+    registered = await commands.getCommands(true);
+  });
+
+  test("the extension is discoverable in the test host", () => {
+    assert.ok(extension, `${EXTENSION_NAME_W_PUBLISHER} not found`);
+  });
+
+  test("the command table matches contributes.commands exactly", () => {
+    const manifestIds = manifest.contributes.commands
+      .map((c: { command: string }) => c.command)
+      .sort();
+    const tableIds = commandList
+      .map((c) => `${EXTENSION_NAME}.${c.name}`)
+      .sort();
+    assert.deepStrictEqual(tableIds, manifestIds);
+  });
+
+  test("every contributed command ID is registered", () => {
+    for (const { command } of manifest.contributes.commands) {
+      assert.ok(registered.includes(command), `${command} not registered`);
+    }
+  });
+
+  test("every keybinding references a registered command", () => {
+    for (const { command } of manifest.contributes.keybindings) {
+      assert.ok(registered.includes(command), `${command} not registered`);
+    }
+  });
+});
+
+suite("passthrough commands", () => {
+  const realExecuteCommand = commands.executeCommand;
+  let calls: string[];
+
+  suiteTeardown(() => {
+    (commands as { executeCommand: any }).executeCommand = realExecuteCommand;
+  });
+
+  setup(() => {
+    calls = [];
+    (commands as { executeCommand: any }).executeCommand = (cmd: string) => {
+      calls.push(cmd);
+      return Promise.resolve();
+    };
+  });
+
+  test("a single-command passthrough runs its built-in", async () => {
+    await commandList.find((c) => c.name === "splitTerminal")!.handler();
+    assert.deepStrictEqual(calls, ["workbench.action.terminal.split"]);
+  });
+
+  test("an array passthrough runs each built-in in order", async () => {
+    await commandList.find((c) => c.name === "toggleMaxTerm")!.handler();
+    assert.deepStrictEqual(calls, [
+      "workbench.action.terminal.focus",
+      "workbench.action.toggleMaximizedPanel",
+    ]);
+  });
+});

--- a/src/test/suite/config.test.ts
+++ b/src/test/suite/config.test.ts
@@ -1,6 +1,11 @@
 import assert from "assert";
-import { workspace, ConfigurationTarget } from "vscode";
-import { inspectScope, writeScoped } from "../../helpers/config";
+import { window, workspace, ConfigurationTarget } from "vscode";
+import {
+  inspectScope,
+  writeScoped,
+  getConfig,
+  updateConfig,
+} from "../../helpers/config";
 
 const SECTION = "terminal.integrated.fontSize";
 
@@ -39,5 +44,69 @@ suite("config scope helpers", () => {
       workspace.getConfiguration().inspect(SECTION)?.globalValue,
       undefined,
     );
+  });
+});
+
+suite("config get/update wrappers", () => {
+  let original: number | undefined;
+
+  suiteSetup(() => {
+    original = workspace.getConfiguration().inspect(SECTION)?.globalValue as
+      | number
+      | undefined;
+  });
+
+  suiteTeardown(async () => {
+    await workspace
+      .getConfiguration()
+      .update(SECTION, original, ConfigurationTarget.Global);
+    await workspace
+      .getConfiguration("terminalAllInOne")
+      .update("disableAllMessages", undefined, ConfigurationTarget.Global);
+  });
+
+  test("getConfig reads a value, with and without a config prefix", async () => {
+    await workspace
+      .getConfiguration()
+      .update(SECTION, 16, ConfigurationTarget.Global);
+    assert.strictEqual(getConfig({ section: SECTION }), 16);
+    await workspace
+      .getConfiguration("terminalAllInOne")
+      .update("disableAllMessages", true, ConfigurationTarget.Global);
+    assert.strictEqual(
+      getConfig({ config: "terminalAllInOne", section: "disableAllMessages" }),
+      true,
+    );
+  });
+
+  test("updateConfig writes at global scope", async () => {
+    await updateConfig({ section: SECTION, value: 18 });
+    assert.strictEqual(
+      workspace.getConfiguration().inspect(SECTION)?.globalValue,
+      18,
+    );
+  });
+
+  test("updateConfig swallows a rejected write into showError", async () => {
+    const realGetConfiguration = workspace.getConfiguration;
+    const realShowError = window.showErrorMessage;
+    let shown: string | undefined;
+    (window as { showErrorMessage: any }).showErrorMessage = (msg: string) => {
+      shown = msg;
+      return Promise.resolve(undefined);
+    };
+    // get() keeps the showError messages-enabled gate working; update() rejects.
+    (workspace as { getConfiguration: any }).getConfiguration = () => ({
+      get: () => undefined,
+      update: () => Promise.reject(new Error("update failed")),
+    });
+    try {
+      await updateConfig({ section: SECTION, value: 1 });
+      assert.strictEqual(shown, "update failed");
+    } finally {
+      (workspace as { getConfiguration: any }).getConfiguration =
+        realGetConfiguration;
+      (window as { showErrorMessage: any }).showErrorMessage = realShowError;
+    }
   });
 });

--- a/src/test/suite/cursor.test.ts
+++ b/src/test/suite/cursor.test.ts
@@ -1,0 +1,71 @@
+import assert from "assert";
+import { window, commands, workspace, ConfigurationTarget } from "vscode";
+import { changeCursorStyle, changeCursorWidth } from "../../commands/cursor";
+
+const BLINK = "terminal.integrated.cursorBlinking";
+const STYLE = "terminal.integrated.cursorStyle";
+const WIDTH = "terminal.integrated.cursorWidth";
+
+suite("cursor commands", () => {
+  const realShowQuickPick = window.showQuickPick;
+  let origBlink: boolean | undefined;
+  let origStyle: string | undefined;
+  let origWidth: number | undefined;
+
+  suiteSetup(() => {
+    const c = workspace.getConfiguration();
+    origBlink = c.inspect(BLINK)?.globalValue as boolean | undefined;
+    origStyle = c.inspect(STYLE)?.globalValue as string | undefined;
+    origWidth = c.inspect(WIDTH)?.globalValue as number | undefined;
+  });
+
+  suiteTeardown(async () => {
+    (window as { showQuickPick: any }).showQuickPick = realShowQuickPick;
+    const c = workspace.getConfiguration();
+    await c.update(BLINK, origBlink, ConfigurationTarget.Global);
+    await c.update(STYLE, origStyle, ConfigurationTarget.Global);
+    await c.update(WIDTH, origWidth, ConfigurationTarget.Global);
+  });
+
+  test("toggleBlinkingCursor flips the setting at global scope", async () => {
+    await workspace
+      .getConfiguration()
+      .update(BLINK, false, ConfigurationTarget.Global);
+    await commands.executeCommand("terminalAllInOne.toggleBlinkingCursor");
+    assert.strictEqual(
+      workspace.getConfiguration().inspect(BLINK)?.globalValue,
+      true,
+    );
+    await commands.executeCommand("terminalAllInOne.toggleBlinkingCursor");
+    assert.strictEqual(workspace.getConfiguration().get(BLINK), false);
+  });
+
+  test("changeCursorStyle persists the picked style", async () => {
+    await workspace
+      .getConfiguration()
+      .update(STYLE, "line", ConfigurationTarget.Global);
+    (window as { showQuickPick: any }).showQuickPick = async (items: any[]) =>
+      items.find((i) => i.label === "block");
+    await changeCursorStyle();
+    assert.strictEqual(workspace.getConfiguration().get(STYLE), "block");
+  });
+
+  test("changeCursorStyle restores on cancel", async () => {
+    await workspace
+      .getConfiguration()
+      .update(STYLE, "underline", ConfigurationTarget.Global);
+    (window as { showQuickPick: any }).showQuickPick = async () => undefined;
+    await changeCursorStyle();
+    assert.strictEqual(workspace.getConfiguration().get(STYLE), "underline");
+  });
+
+  test("changeCursorWidth parses the picked label to a number", async () => {
+    await workspace
+      .getConfiguration()
+      .update(WIDTH, 1, ConfigurationTarget.Global);
+    (window as { showQuickPick: any }).showQuickPick = async (items: any[]) =>
+      items.find((i) => i.label === "5-pt");
+    await changeCursorWidth();
+    assert.strictEqual(workspace.getConfiguration().get(WIDTH), 5);
+  });
+});

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,11 +1,95 @@
 import assert from "assert";
-import { window } from "vscode";
-import { activate, deactivate } from "../../extension";
+import { window, ExtensionContext } from "vscode";
+import {
+  activate,
+  deactivate,
+  onFirstActivate,
+  timeSinceInstall,
+} from "../../extension";
+import { stateProps } from "../../helpers/constants";
+import { DAY_MS } from "../../helpers/time";
 
-suite("Extension Test Suite", () => {
-  window.showInformationMessage("Start all tests.");
+function fakeContext(initial: Record<string, unknown> = {}) {
+  const store = new Map(Object.entries(initial));
+  const context = {
+    globalState: {
+      get: (key: string) => store.get(key),
+      update: (key: string, value: unknown) => {
+        store.set(key, value);
+        return Promise.resolve();
+      },
+    },
+  } as unknown as ExtensionContext;
+  return { context, store };
+}
 
-  assert.ok(activate, "Activate Function exists");
+suite("extension startup gating", () => {
+  const realInfo = window.showInformationMessage;
 
-  assert.ok(deactivate, "Deactivate Function exists");
+  suiteSetup(() => {
+    // Silence the welcome / rating prompts so the gating logic runs without UI.
+    (window as { showInformationMessage: any }).showInformationMessage =
+      async () => undefined;
+  });
+
+  suiteTeardown(() => {
+    (window as { showInformationMessage: any }).showInformationMessage =
+      realInfo;
+  });
+
+  test("activate and deactivate are exported", () => {
+    assert.ok(activate);
+    assert.ok(deactivate);
+  });
+
+  test("onFirstActivate records the install date on a fresh install", () => {
+    const { context, store } = fakeContext();
+    onFirstActivate(context);
+    assert.strictEqual(typeof store.get(stateProps.LAST_FOLLOW_UP), "number");
+  });
+
+  test("onFirstActivate does nothing when already installed", () => {
+    const { context, store } = fakeContext({
+      [stateProps.LAST_FOLLOW_UP]: 123,
+    });
+    onFirstActivate(context);
+    assert.strictEqual(store.get(stateProps.LAST_FOLLOW_UP), 123);
+  });
+
+  test("timeSinceInstall re-stamps after 30+ days", () => {
+    const old = Date.now() - 40 * DAY_MS;
+    const { context, store } = fakeContext({
+      [stateProps.LAST_FOLLOW_UP]: old,
+    });
+    timeSinceInstall(context);
+    assert.ok(
+      (store.get(stateProps.LAST_FOLLOW_UP) as number) > old,
+      "expected the follow-up date to advance",
+    );
+  });
+
+  test("timeSinceInstall does nothing before 30 days", () => {
+    const recent = Date.now() - 10 * DAY_MS;
+    const { context, store } = fakeContext({
+      [stateProps.LAST_FOLLOW_UP]: recent,
+    });
+    timeSinceInstall(context);
+    assert.strictEqual(store.get(stateProps.LAST_FOLLOW_UP), recent);
+  });
+
+  test("timeSinceInstall does nothing when the user opted out", () => {
+    const old = Date.now() - 40 * DAY_MS;
+    const { context, store } = fakeContext({
+      [stateProps.LAST_FOLLOW_UP]: old,
+      [stateProps.SHOULD_NOT_SHOW_FOLLOW_UP]: true,
+    });
+    timeSinceInstall(context);
+    assert.strictEqual(store.get(stateProps.LAST_FOLLOW_UP), old);
+  });
+
+  test("timeSinceInstall does nothing when never installed", () => {
+    const { context, store } = fakeContext();
+    timeSinceInstall(context);
+    assert.strictEqual(store.get(stateProps.LAST_FOLLOW_UP), undefined);
+  });
 });

--- a/src/test/suite/fontSize.test.ts
+++ b/src/test/suite/fontSize.test.ts
@@ -1,0 +1,58 @@
+import assert from "assert";
+import { window, commands, workspace, ConfigurationTarget } from "vscode";
+import { changeFontSize } from "../../commands/fontSize";
+
+const SECTION = "terminal.integrated.fontSize";
+const tick = () => new Promise((r) => setTimeout(r, 100));
+
+suite("fontSize commands", () => {
+  const realShowQuickPick = window.showQuickPick;
+  let original: number | undefined;
+
+  suiteSetup(() => {
+    original = workspace.getConfiguration().inspect(SECTION)?.globalValue as
+      | number
+      | undefined;
+  });
+
+  suiteTeardown(async () => {
+    (window as { showQuickPick: any }).showQuickPick = realShowQuickPick;
+    await workspace
+      .getConfiguration()
+      .update(SECTION, original, ConfigurationTarget.Global);
+  });
+
+  test("increase then decrease adjusts by 1 at global scope", async () => {
+    await workspace
+      .getConfiguration()
+      .update(SECTION, 12, ConfigurationTarget.Global);
+    await commands.executeCommand("terminalAllInOne.increaseFontSize");
+    await tick();
+    assert.strictEqual(
+      workspace.getConfiguration().inspect(SECTION)?.globalValue,
+      13,
+    );
+    await commands.executeCommand("terminalAllInOne.decreaseFontSize");
+    await tick();
+    assert.strictEqual(workspace.getConfiguration().get(SECTION), 12);
+  });
+
+  test("changeFontSize persists the picked size", async () => {
+    await workspace
+      .getConfiguration()
+      .update(SECTION, 12, ConfigurationTarget.Global);
+    (window as { showQuickPick: any }).showQuickPick = async (items: any[]) =>
+      items.find((i) => i.label === "16-pt");
+    await changeFontSize();
+    assert.strictEqual(workspace.getConfiguration().get(SECTION), 16);
+  });
+
+  test("changeFontSize restores on cancel", async () => {
+    await workspace
+      .getConfiguration()
+      .update(SECTION, 11, ConfigurationTarget.Global);
+    (window as { showQuickPick: any }).showQuickPick = async () => undefined;
+    await changeFontSize();
+    assert.strictEqual(workspace.getConfiguration().get(SECTION), 11);
+  });
+});

--- a/src/test/suite/messages.test.ts
+++ b/src/test/suite/messages.test.ts
@@ -1,0 +1,60 @@
+import assert from "assert";
+import { window, commands, workspace, ConfigurationTarget } from "vscode";
+import { messagesEnabled, showWelcome, showError } from "../../messages";
+
+const DISABLE = "disableAllMessages";
+
+suite("messages", () => {
+  const realInfo = window.showInformationMessage;
+  const realErr = window.showErrorMessage;
+  const realExec = commands.executeCommand;
+
+  suiteTeardown(async () => {
+    (window as { showInformationMessage: any }).showInformationMessage =
+      realInfo;
+    (window as { showErrorMessage: any }).showErrorMessage = realErr;
+    (commands as { executeCommand: any }).executeCommand = realExec;
+    await workspace
+      .getConfiguration("terminalAllInOne")
+      .update(DISABLE, undefined, ConfigurationTarget.Global);
+  });
+
+  async function setDisabled(v: boolean | undefined) {
+    await workspace
+      .getConfiguration("terminalAllInOne")
+      .update(DISABLE, v, ConfigurationTarget.Global);
+  }
+
+  test("messagesEnabled reflects the disableAllMessages setting", async () => {
+    await setDisabled(true);
+    assert.strictEqual(messagesEnabled(), false);
+    await setDisabled(false);
+    assert.strictEqual(messagesEnabled(), true);
+  });
+
+  test("showWelcome opens the README when the button is clicked", async () => {
+    await setDisabled(false);
+    (window as { showInformationMessage: any }).showInformationMessage =
+      async () => "README";
+    let opened: string | undefined;
+    (commands as { executeCommand: any }).executeCommand = async (
+      cmd: string,
+      arg?: string,
+    ) => {
+      if (cmd === "extension.open") opened = arg;
+    };
+    await showWelcome();
+    assert.strictEqual(opened, "yasht.terminal-all-in-one");
+  });
+
+  test("showError stays silent when messages are disabled", async () => {
+    await setDisabled(true);
+    let called = false;
+    (window as { showErrorMessage: any }).showErrorMessage = () => {
+      called = true;
+      return Promise.resolve(undefined);
+    };
+    showError("boom");
+    assert.strictEqual(called, false);
+  });
+});

--- a/src/test/suite/runScript.test.ts
+++ b/src/test/suite/runScript.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { window, commands, workspace, ConfigurationTarget } from "vscode";
-import { execute } from "../../commands/runScript";
+import { execute, runScript, getScriptsConfig } from "../../commands/runScript";
 
 suite("runScript execute", () => {
   const realCreateTerminal = window.createTerminal;
@@ -74,5 +74,122 @@ suite("runScript execute", () => {
       .update("script.disableAutoRun", true, ConfigurationTarget.Global);
     await execute({ name: "Solo", script: "echo hi" });
     assert.strictEqual(sequence, "echo hi");
+  });
+});
+
+suite("getScriptsConfig", () => {
+  suiteTeardown(async () => {
+    await workspace
+      .getConfiguration("terminalAllInOne")
+      .update("scripts", undefined, ConfigurationTarget.Global);
+  });
+
+  test("keeps valid entries and drops malformed ones", async () => {
+    await workspace
+      .getConfiguration("terminalAllInOne")
+      .update(
+        "scripts",
+        [
+          { name: "ok", script: "echo hi" },
+          { name: "arr", script: ["a", "b"] },
+          { name: "missingScript" },
+          { script: "missingName" },
+          "not an object",
+          null,
+          { name: 1, script: "badName" },
+        ],
+        ConfigurationTarget.Global,
+      );
+    assert.deepStrictEqual(getScriptsConfig(), [
+      { name: "ok", script: "echo hi" },
+      { name: "arr", script: ["a", "b"] },
+    ]);
+  });
+
+  test("returns [] when scripts is unset", async () => {
+    await workspace
+      .getConfiguration("terminalAllInOne")
+      .update("scripts", undefined, ConfigurationTarget.Global);
+    assert.deepStrictEqual(getScriptsConfig(), []);
+  });
+});
+
+suite("runScript routing", () => {
+  const realShowQuickPick = window.showQuickPick;
+  const realShowWarningMessage = window.showWarningMessage;
+  const realExecuteCommand = commands.executeCommand;
+  const realCreateTerminal = window.createTerminal;
+  let sequence: string | undefined;
+  let warning: string | undefined;
+
+  suiteTeardown(async () => {
+    (window as { showQuickPick: any }).showQuickPick = realShowQuickPick;
+    (window as { showWarningMessage: any }).showWarningMessage =
+      realShowWarningMessage;
+    (commands as { executeCommand: any }).executeCommand = realExecuteCommand;
+    (window as { createTerminal: any }).createTerminal = realCreateTerminal;
+    await workspace
+      .getConfiguration("terminalAllInOne")
+      .update("scripts", undefined, ConfigurationTarget.Global);
+  });
+
+  setup(() => {
+    sequence = undefined;
+    warning = undefined;
+    (window as { createTerminal: any }).createTerminal = () => ({ show() {} });
+    (window as { showWarningMessage: any }).showWarningMessage = (
+      msg: string,
+    ) => {
+      warning = msg;
+      return Promise.resolve(undefined);
+    };
+    (commands as { executeCommand: any }).executeCommand = (
+      command: string,
+      args?: { text?: string },
+    ) => {
+      if (command === "workbench.action.terminal.sendSequence") {
+        sequence = args?.text;
+      }
+      return Promise.resolve();
+    };
+  });
+
+  async function setScripts(scripts: unknown[]) {
+    await workspace
+      .getConfiguration("terminalAllInOne")
+      .update("scripts", scripts, ConfigurationTarget.Global);
+  }
+
+  test("a valid index runs that script", async () => {
+    await setScripts([
+      { name: "first", script: "echo one" },
+      { name: "second", script: "echo two" },
+    ]);
+    await runScript(1);
+    assert.strictEqual(sequence, "echo two\r");
+  });
+
+  test("an out-of-range index warns and runs nothing", async () => {
+    await setScripts([{ name: "only", script: "echo one" }]);
+    await runScript(5);
+    assert.strictEqual(sequence, undefined);
+    assert.strictEqual(warning, "No script has been defined for that index");
+  });
+
+  test("no scripts and no index warns", async () => {
+    await setScripts([]);
+    await runScript();
+    assert.strictEqual(warning, "No scripts have been defined");
+  });
+
+  test("the picker runs the selected script", async () => {
+    await setScripts([
+      { name: "first", script: "echo one" },
+      { name: "second", script: "echo two" },
+    ]);
+    (window as { showQuickPick: any }).showQuickPick = async (items: any[]) =>
+      items[1];
+    await runScript();
+    assert.strictEqual(sequence, "echo two\r");
   });
 });


### PR DESCRIPTION
Closes #441. Raises coverage across the command layer, startup gating, and messages, and adds a manifest↔registration parity test that guards the stable command contract (every `contributes.commands` ID is registered with no extras, and every keybinding references a real command). The only source changes are five added `export` keywords (`getScriptsConfig`, `applyTheme`, `messagesEnabled`, `onFirstActivate`, `timeSinceInstall`) to reach internals the public path can't test cleanly — there is no behavioral change. New and expanded tests cover non-interactive commands via real config round-trips, interactive pickers (persist-on-accept / restore-on-cancel) via stubbed quick picks, malformed-script filtering, theme merge/`None`-strip/unknown paths, the messages-enabled gate and button wiring, and startup gating against a fake in-memory `ExtensionContext`. The suite grows from 14 to 55 passing tests with `lint`, `typecheck`, and `test` all green.

## Test Plan
- [ ] `pnpm run lint`
- [ ] `pnpm run typecheck`
- [ ] `pnpm test` (55 passing)