### PR TITLE
Dedupe test boilerplate into a shared test helper (#444)

### DIFF
--- a/src/test/suite/changeFontWeight.test.ts
+++ b/src/test/suite/changeFontWeight.test.ts
@@ -1,52 +1,43 @@
 import assert from "assert";
-import { window, workspace, ConfigurationTarget } from "vscode";
+import { window } from "vscode";
 import { changeFontWeight } from "../../commands/changeFontWeight";
+import { stub, globalSetting } from "./helpers";
 
 const SECTION = "terminal.integrated.fontWeight";
 
 suite("changeFontWeight", () => {
   const realShowQuickPick = window.showQuickPick;
-  let original: string | undefined;
+  const weight = globalSetting<string>(SECTION);
 
-  suiteSetup(() => {
-    original = workspace.getConfiguration().inspect(SECTION)?.globalValue as
-      | string
-      | undefined;
-  });
+  suiteSetup(weight.capture);
 
   suiteTeardown(async () => {
-    (window as { showQuickPick: any }).showQuickPick = realShowQuickPick;
-    await workspace
-      .getConfiguration()
-      .update(SECTION, original, ConfigurationTarget.Global);
+    stub(window, "showQuickPick", realShowQuickPick);
+    await weight.restore();
   });
 
   test("persists the picked weight", async () => {
-    await workspace
-      .getConfiguration()
-      .update(SECTION, "normal", ConfigurationTarget.Global);
-    (window as { showQuickPick: any }).showQuickPick = async (items: any[]) =>
-      items.find((i) => i.label === "bold");
+    await weight.set("normal");
+    stub(window, "showQuickPick", async (items: any[]) =>
+      items.find((i) => i.label === "bold"),
+    );
     await changeFontWeight();
-    assert.strictEqual(workspace.getConfiguration().get(SECTION), "bold");
+    assert.strictEqual(weight.value(), "bold");
   });
 
   test("persists a numeric weight string", async () => {
-    await workspace
-      .getConfiguration()
-      .update(SECTION, "normal", ConfigurationTarget.Global);
-    (window as { showQuickPick: any }).showQuickPick = async (items: any[]) =>
-      items.find((i) => i.label === "300");
+    await weight.set("normal");
+    stub(window, "showQuickPick", async (items: any[]) =>
+      items.find((i) => i.label === "300"),
+    );
     await changeFontWeight();
-    assert.strictEqual(workspace.getConfiguration().get(SECTION), "300");
+    assert.strictEqual(weight.value(), "300");
   });
 
   test("restores on cancel", async () => {
-    await workspace
-      .getConfiguration()
-      .update(SECTION, "bold", ConfigurationTarget.Global);
-    (window as { showQuickPick: any }).showQuickPick = async () => undefined;
+    await weight.set("bold");
+    stub(window, "showQuickPick", async () => undefined);
     await changeFontWeight();
-    assert.strictEqual(workspace.getConfiguration().get(SECTION), "bold");
+    assert.strictEqual(weight.value(), "bold");
   });
 });

--- a/src/test/suite/chooseTerminalTheme.test.ts
+++ b/src/test/suite/chooseTerminalTheme.test.ts
@@ -1,117 +1,95 @@
 import assert from "assert";
-import { window, workspace, ConfigurationTarget } from "vscode";
+import { window } from "vscode";
 import {
   applyTheme,
   onTerminalThemeChange,
   chooseTerminalTheme,
 } from "../../commands/chooseTerminalTheme";
 import themes from "../../themes.json";
+import { tick, stub, globalSetting } from "./helpers";
 
 const COLORS = "workbench.colorCustomizations";
 const THEME = "terminalAllInOne.terminalTheme";
 const sample = themes[0];
 
-function colorsValue() {
-  return workspace.getConfiguration().inspect(COLORS)?.globalValue as
-    | Record<string, string>
-    | undefined;
-}
-async function setColors(value: Record<string, string> | undefined) {
-  await workspace
-    .getConfiguration()
-    .update(COLORS, value, ConfigurationTarget.Global);
-}
-const tick = () => new Promise((r) => setTimeout(r, 100));
-
 suite("chooseTerminalTheme", () => {
   const realShowQuickPick = window.showQuickPick;
   const realShowErrorMessage = window.showErrorMessage;
-  let originalColors: Record<string, string> | undefined;
-  let originalTheme: string | undefined;
+  const colors = globalSetting<Record<string, string>>(COLORS);
+  const theme = globalSetting<string>(THEME);
 
   suiteSetup(() => {
-    originalColors = colorsValue();
-    originalTheme = workspace.getConfiguration().inspect(THEME)?.globalValue as
-      | string
-      | undefined;
+    colors.capture();
+    theme.capture();
   });
 
   suiteTeardown(async () => {
-    (window as { showQuickPick: any }).showQuickPick = realShowQuickPick;
-    (window as { showErrorMessage: any }).showErrorMessage =
-      realShowErrorMessage;
-    await setColors(originalColors);
-    await workspace
-      .getConfiguration()
-      .update(THEME, originalTheme, ConfigurationTarget.Global);
+    stub(window, "showQuickPick", realShowQuickPick);
+    stub(window, "showErrorMessage", realShowErrorMessage);
+    await colors.restore();
+    await theme.restore();
   });
 
   test("applyTheme merges the theme's colors onto existing customizations", async () => {
-    await setColors({ "editor.background": "#123456" });
+    await colors.set({ "editor.background": "#123456" });
     await applyTheme(sample.name);
-    assert.deepStrictEqual(colorsValue(), {
+    assert.deepStrictEqual(colors.value(), {
       "editor.background": "#123456",
       ...sample.colors,
     });
   });
 
   test("applyTheme('None') strips terminal colors, keeping the rest", async () => {
-    await setColors({
+    await colors.set({
       "editor.background": "#123456",
       "terminal.background": "#000000",
       "terminalCursor.foreground": "#ffffff",
     });
     await applyTheme("None");
-    assert.deepStrictEqual(colorsValue(), { "editor.background": "#123456" });
+    assert.deepStrictEqual(colors.value(), { "editor.background": "#123456" });
   });
 
   test("applyTheme on an unknown theme errors and writes nothing", async () => {
-    await setColors({ "editor.background": "#123456" });
+    await colors.set({ "editor.background": "#123456" });
     let shown = false;
-    (window as { showErrorMessage: any }).showErrorMessage = () => {
+    stub(window, "showErrorMessage", () => {
       shown = true;
       return Promise.resolve(undefined);
-    };
+    });
     await applyTheme("Definitely Not A Real Theme");
     assert.ok(shown, "expected the theme-does-not-exist error");
-    assert.deepStrictEqual(colorsValue(), { "editor.background": "#123456" });
+    assert.deepStrictEqual(colors.value(), { "editor.background": "#123456" });
   });
 
   test("onTerminalThemeChange applies the saved theme only when affected", async () => {
-    await workspace
-      .getConfiguration()
-      .update(THEME, sample.name, ConfigurationTarget.Global);
+    await theme.set(sample.name);
     await tick();
-    await setColors({});
+    await colors.set({});
     onTerminalThemeChange({
       affectsConfiguration: (s: string) => s === THEME,
     } as any);
     await tick();
-    assert.deepStrictEqual(colorsValue(), { ...sample.colors });
+    assert.deepStrictEqual(colors.value(), { ...sample.colors });
 
-    await setColors({ "editor.background": "#123456" });
+    await colors.set({ "editor.background": "#123456" });
     onTerminalThemeChange({ affectsConfiguration: () => false } as any);
     await tick();
-    assert.deepStrictEqual(colorsValue(), { "editor.background": "#123456" });
+    assert.deepStrictEqual(colors.value(), { "editor.background": "#123456" });
   });
 
   test("the picker persists the chosen theme name on accept", async () => {
-    await workspace
-      .getConfiguration()
-      .update(THEME, "None", ConfigurationTarget.Global);
-    (window as { showQuickPick: any }).showQuickPick = async () => ({
-      label: sample.name,
-    });
+    await theme.set("None");
+    stub(window, "showQuickPick", async () => ({ label: sample.name }));
     await chooseTerminalTheme();
     // chooseTerminalTheme persists the theme name without awaiting the write.
     await tick();
-    assert.strictEqual(workspace.getConfiguration().get(THEME), sample.name);
+    assert.strictEqual(theme.value(), sample.name);
   });
 
   test("the picker restores colorCustomizations on cancel", async () => {
-    await setColors({ "editor.background": "#abcabc" });
-    (window as { showQuickPick: any }).showQuickPick = async () => undefined;
+    await colors.set({ "editor.background": "#abcabc" });
+    stub(window, "showQuickPick", async () => undefined);
     await chooseTerminalTheme();
-    assert.deepStrictEqual(colorsValue(), { "editor.background": "#abcabc" });
+    assert.deepStrictEqual(colors.value(), { "editor.background": "#abcabc" });
   });
 });

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -5,6 +5,7 @@ import {
   EXTENSION_NAME_W_PUBLISHER,
 } from "../../helpers/constants";
 import commandList from "../../commands";
+import { stub } from "./helpers";
 
 suite("manifest ↔ registration parity", () => {
   const extension = extensions.getExtension(EXTENSION_NAME_W_PUBLISHER);
@@ -49,15 +50,15 @@ suite("passthrough commands", () => {
   let calls: string[];
 
   suiteTeardown(() => {
-    (commands as { executeCommand: any }).executeCommand = realExecuteCommand;
+    stub(commands, "executeCommand", realExecuteCommand);
   });
 
   setup(() => {
     calls = [];
-    (commands as { executeCommand: any }).executeCommand = (cmd: string) => {
+    stub(commands, "executeCommand", (cmd: string) => {
       calls.push(cmd);
       return Promise.resolve();
-    };
+    });
   });
 
   test("a single-command passthrough runs its built-in", async () => {

--- a/src/test/suite/config.test.ts
+++ b/src/test/suite/config.test.ts
@@ -38,11 +38,14 @@ suite("config get/update wrappers", () => {
     "terminalAllInOne",
   );
 
-  suiteSetup(size.capture);
+  suiteSetup(() => {
+    size.capture();
+    disabled.capture();
+  });
 
   suiteTeardown(async () => {
     await size.restore();
-    await disabled.set(undefined);
+    await disabled.restore();
   });
 
   test("getConfig reads a value, with and without a config prefix", async () => {

--- a/src/test/suite/config.test.ts
+++ b/src/test/suite/config.test.ts
@@ -6,28 +6,18 @@ import {
   getConfig,
   updateConfig,
 } from "../../helpers/config";
+import { stub, globalSetting } from "./helpers";
 
 const SECTION = "terminal.integrated.fontSize";
 
 suite("config scope helpers", () => {
-  let original: number | undefined;
+  const size = globalSetting<number>(SECTION);
 
-  suiteSetup(() => {
-    original = workspace.getConfiguration().inspect(SECTION)?.globalValue as
-      | number
-      | undefined;
-  });
-
-  suiteTeardown(async () => {
-    await workspace
-      .getConfiguration()
-      .update(SECTION, original, ConfigurationTarget.Global);
-  });
+  suiteSetup(size.capture);
+  suiteTeardown(size.restore);
 
   test("inspectScope resolves the global value and target", async () => {
-    await workspace
-      .getConfiguration()
-      .update(SECTION, 15, ConfigurationTarget.Global);
+    await size.set(15);
     const scope = inspectScope(SECTION);
     assert.strictEqual(scope.target, ConfigurationTarget.Global);
     assert.strictEqual(scope.value, 15);
@@ -35,44 +25,30 @@ suite("config scope helpers", () => {
 
   test("writeScoped writes at the target, and undefined clears back to default", async () => {
     await writeScoped(SECTION, 20, ConfigurationTarget.Global);
-    assert.strictEqual(
-      workspace.getConfiguration().inspect(SECTION)?.globalValue,
-      20,
-    );
+    assert.strictEqual(size.value(), 20);
     await writeScoped(SECTION, undefined, ConfigurationTarget.Global);
-    assert.strictEqual(
-      workspace.getConfiguration().inspect(SECTION)?.globalValue,
-      undefined,
-    );
+    assert.strictEqual(size.value(), undefined);
   });
 });
 
 suite("config get/update wrappers", () => {
-  let original: number | undefined;
+  const size = globalSetting<number>(SECTION);
+  const disabled = globalSetting<boolean>(
+    "disableAllMessages",
+    "terminalAllInOne",
+  );
 
-  suiteSetup(() => {
-    original = workspace.getConfiguration().inspect(SECTION)?.globalValue as
-      | number
-      | undefined;
-  });
+  suiteSetup(size.capture);
 
   suiteTeardown(async () => {
-    await workspace
-      .getConfiguration()
-      .update(SECTION, original, ConfigurationTarget.Global);
-    await workspace
-      .getConfiguration("terminalAllInOne")
-      .update("disableAllMessages", undefined, ConfigurationTarget.Global);
+    await size.restore();
+    await disabled.set(undefined);
   });
 
   test("getConfig reads a value, with and without a config prefix", async () => {
-    await workspace
-      .getConfiguration()
-      .update(SECTION, 16, ConfigurationTarget.Global);
+    await size.set(16);
     assert.strictEqual(getConfig({ section: SECTION }), 16);
-    await workspace
-      .getConfiguration("terminalAllInOne")
-      .update("disableAllMessages", true, ConfigurationTarget.Global);
+    await disabled.set(true);
     assert.strictEqual(
       getConfig({ config: "terminalAllInOne", section: "disableAllMessages" }),
       true,
@@ -81,32 +57,28 @@ suite("config get/update wrappers", () => {
 
   test("updateConfig writes at global scope", async () => {
     await updateConfig({ section: SECTION, value: 18 });
-    assert.strictEqual(
-      workspace.getConfiguration().inspect(SECTION)?.globalValue,
-      18,
-    );
+    assert.strictEqual(size.value(), 18);
   });
 
   test("updateConfig swallows a rejected write into showError", async () => {
     const realGetConfiguration = workspace.getConfiguration;
     const realShowError = window.showErrorMessage;
     let shown: string | undefined;
-    (window as { showErrorMessage: any }).showErrorMessage = (msg: string) => {
+    stub(window, "showErrorMessage", (msg: string) => {
       shown = msg;
       return Promise.resolve(undefined);
-    };
+    });
     // get() keeps the showError messages-enabled gate working; update() rejects.
-    (workspace as { getConfiguration: any }).getConfiguration = () => ({
+    stub(workspace, "getConfiguration", () => ({
       get: () => undefined,
       update: () => Promise.reject(new Error("update failed")),
-    });
+    }));
     try {
       await updateConfig({ section: SECTION, value: 1 });
       assert.strictEqual(shown, "update failed");
     } finally {
-      (workspace as { getConfiguration: any }).getConfiguration =
-        realGetConfiguration;
-      (window as { showErrorMessage: any }).showErrorMessage = realShowError;
+      stub(workspace, "getConfiguration", realGetConfiguration);
+      stub(window, "showErrorMessage", realShowError);
     }
   });
 });

--- a/src/test/suite/cursor.test.ts
+++ b/src/test/suite/cursor.test.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
-import { window, commands, workspace, ConfigurationTarget } from "vscode";
+import { window, commands } from "vscode";
 import { changeCursorStyle, changeCursorWidth } from "../../commands/cursor";
+import { stub, globalSetting } from "./helpers";
 
 const BLINK = "terminal.integrated.cursorBlinking";
 const STYLE = "terminal.integrated.cursorStyle";
@@ -8,64 +9,53 @@ const WIDTH = "terminal.integrated.cursorWidth";
 
 suite("cursor commands", () => {
   const realShowQuickPick = window.showQuickPick;
-  let origBlink: boolean | undefined;
-  let origStyle: string | undefined;
-  let origWidth: number | undefined;
+  const blink = globalSetting<boolean>(BLINK);
+  const style = globalSetting<string>(STYLE);
+  const width = globalSetting<number>(WIDTH);
 
   suiteSetup(() => {
-    const c = workspace.getConfiguration();
-    origBlink = c.inspect(BLINK)?.globalValue as boolean | undefined;
-    origStyle = c.inspect(STYLE)?.globalValue as string | undefined;
-    origWidth = c.inspect(WIDTH)?.globalValue as number | undefined;
+    blink.capture();
+    style.capture();
+    width.capture();
   });
 
   suiteTeardown(async () => {
-    (window as { showQuickPick: any }).showQuickPick = realShowQuickPick;
-    const c = workspace.getConfiguration();
-    await c.update(BLINK, origBlink, ConfigurationTarget.Global);
-    await c.update(STYLE, origStyle, ConfigurationTarget.Global);
-    await c.update(WIDTH, origWidth, ConfigurationTarget.Global);
+    stub(window, "showQuickPick", realShowQuickPick);
+    await blink.restore();
+    await style.restore();
+    await width.restore();
   });
 
   test("toggleBlinkingCursor flips the setting at global scope", async () => {
-    await workspace
-      .getConfiguration()
-      .update(BLINK, false, ConfigurationTarget.Global);
+    await blink.set(false);
     await commands.executeCommand("terminalAllInOne.toggleBlinkingCursor");
-    assert.strictEqual(
-      workspace.getConfiguration().inspect(BLINK)?.globalValue,
-      true,
-    );
+    assert.strictEqual(blink.value(), true);
     await commands.executeCommand("terminalAllInOne.toggleBlinkingCursor");
-    assert.strictEqual(workspace.getConfiguration().get(BLINK), false);
+    assert.strictEqual(blink.value(), false);
   });
 
   test("changeCursorStyle persists the picked style", async () => {
-    await workspace
-      .getConfiguration()
-      .update(STYLE, "line", ConfigurationTarget.Global);
-    (window as { showQuickPick: any }).showQuickPick = async (items: any[]) =>
-      items.find((i) => i.label === "block");
+    await style.set("line");
+    stub(window, "showQuickPick", async (items: any[]) =>
+      items.find((i) => i.label === "block"),
+    );
     await changeCursorStyle();
-    assert.strictEqual(workspace.getConfiguration().get(STYLE), "block");
+    assert.strictEqual(style.value(), "block");
   });
 
   test("changeCursorStyle restores on cancel", async () => {
-    await workspace
-      .getConfiguration()
-      .update(STYLE, "underline", ConfigurationTarget.Global);
-    (window as { showQuickPick: any }).showQuickPick = async () => undefined;
+    await style.set("underline");
+    stub(window, "showQuickPick", async () => undefined);
     await changeCursorStyle();
-    assert.strictEqual(workspace.getConfiguration().get(STYLE), "underline");
+    assert.strictEqual(style.value(), "underline");
   });
 
   test("changeCursorWidth parses the picked label to a number", async () => {
-    await workspace
-      .getConfiguration()
-      .update(WIDTH, 1, ConfigurationTarget.Global);
-    (window as { showQuickPick: any }).showQuickPick = async (items: any[]) =>
-      items.find((i) => i.label === "5-pt");
+    await width.set(1);
+    stub(window, "showQuickPick", async (items: any[]) =>
+      items.find((i) => i.label === "5-pt"),
+    );
     await changeCursorWidth();
-    assert.strictEqual(workspace.getConfiguration().get(WIDTH), 5);
+    assert.strictEqual(width.value(), 5);
   });
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../extension";
 import { stateProps } from "../../helpers/constants";
 import { DAY_MS } from "../../helpers/time";
+import { stub } from "./helpers";
 
 function fakeContext(initial: Record<string, unknown> = {}) {
   const store = new Map(Object.entries(initial));
@@ -28,13 +29,11 @@ suite("extension startup gating", () => {
 
   suiteSetup(() => {
     // Silence the welcome / rating prompts so the gating logic runs without UI.
-    (window as { showInformationMessage: any }).showInformationMessage =
-      async () => undefined;
+    stub(window, "showInformationMessage", async () => undefined);
   });
 
   suiteTeardown(() => {
-    (window as { showInformationMessage: any }).showInformationMessage =
-      realInfo;
+    stub(window, "showInformationMessage", realInfo);
   });
 
   test("activate and deactivate are exported", () => {

--- a/src/test/suite/fontSize.test.ts
+++ b/src/test/suite/fontSize.test.ts
@@ -1,58 +1,44 @@
 import assert from "assert";
-import { window, commands, workspace, ConfigurationTarget } from "vscode";
+import { window, commands } from "vscode";
 import { changeFontSize } from "../../commands/fontSize";
+import { tick, stub, globalSetting } from "./helpers";
 
 const SECTION = "terminal.integrated.fontSize";
-const tick = () => new Promise((r) => setTimeout(r, 100));
 
 suite("fontSize commands", () => {
   const realShowQuickPick = window.showQuickPick;
-  let original: number | undefined;
+  const size = globalSetting<number>(SECTION);
 
-  suiteSetup(() => {
-    original = workspace.getConfiguration().inspect(SECTION)?.globalValue as
-      | number
-      | undefined;
-  });
+  suiteSetup(size.capture);
 
   suiteTeardown(async () => {
-    (window as { showQuickPick: any }).showQuickPick = realShowQuickPick;
-    await workspace
-      .getConfiguration()
-      .update(SECTION, original, ConfigurationTarget.Global);
+    stub(window, "showQuickPick", realShowQuickPick);
+    await size.restore();
   });
 
   test("increase then decrease adjusts by 1 at global scope", async () => {
-    await workspace
-      .getConfiguration()
-      .update(SECTION, 12, ConfigurationTarget.Global);
+    await size.set(12);
     await commands.executeCommand("terminalAllInOne.increaseFontSize");
     await tick();
-    assert.strictEqual(
-      workspace.getConfiguration().inspect(SECTION)?.globalValue,
-      13,
-    );
+    assert.strictEqual(size.value(), 13);
     await commands.executeCommand("terminalAllInOne.decreaseFontSize");
     await tick();
-    assert.strictEqual(workspace.getConfiguration().get(SECTION), 12);
+    assert.strictEqual(size.value(), 12);
   });
 
   test("changeFontSize persists the picked size", async () => {
-    await workspace
-      .getConfiguration()
-      .update(SECTION, 12, ConfigurationTarget.Global);
-    (window as { showQuickPick: any }).showQuickPick = async (items: any[]) =>
-      items.find((i) => i.label === "16-pt");
+    await size.set(12);
+    stub(window, "showQuickPick", async (items: any[]) =>
+      items.find((i) => i.label === "16-pt"),
+    );
     await changeFontSize();
-    assert.strictEqual(workspace.getConfiguration().get(SECTION), 16);
+    assert.strictEqual(size.value(), 16);
   });
 
   test("changeFontSize restores on cancel", async () => {
-    await workspace
-      .getConfiguration()
-      .update(SECTION, 11, ConfigurationTarget.Global);
-    (window as { showQuickPick: any }).showQuickPick = async () => undefined;
+    await size.set(11);
+    stub(window, "showQuickPick", async () => undefined);
     await changeFontSize();
-    assert.strictEqual(workspace.getConfiguration().get(SECTION), 11);
+    assert.strictEqual(size.value(), 11);
   });
 });

--- a/src/test/suite/helpers.ts
+++ b/src/test/suite/helpers.ts
@@ -2,7 +2,7 @@ import { workspace, ConfigurationTarget } from "vscode";
 
 export const tick = () => new Promise((r) => setTimeout(r, 100));
 
-// Swap a (readonly) method on window/commands for a stub; pass the saved original back to restore it.
+// Overwrite a readonly method with a stub; pass the saved original back to restore.
 export function stub<T, K extends keyof T>(
   obj: T,
   key: K,

--- a/src/test/suite/helpers.ts
+++ b/src/test/suite/helpers.ts
@@ -1,0 +1,27 @@
+import { workspace, ConfigurationTarget } from "vscode";
+
+export const tick = () => new Promise((r) => setTimeout(r, 100));
+
+// Swap a (readonly) method on window/commands for a stub; pass the saved original back to restore it.
+export function stub<T, K extends keyof T>(
+  obj: T,
+  key: K,
+  impl: unknown,
+): void {
+  (obj as Record<K, unknown>)[key] = impl;
+}
+
+// A global-scoped setting: capture the original (suiteSetup), set/read it, restore (suiteTeardown).
+export function globalSetting<T>(section: string, config?: string) {
+  const cfg = () => workspace.getConfiguration(config);
+  let original: T | undefined;
+  return {
+    capture: () => {
+      original = cfg().inspect(section)?.globalValue as T | undefined;
+    },
+    value: () => cfg().inspect(section)?.globalValue as T | undefined,
+    set: (value: T | undefined) =>
+      cfg().update(section, value, ConfigurationTarget.Global),
+    restore: () => cfg().update(section, original, ConfigurationTarget.Global),
+  };
+}

--- a/src/test/suite/livePreview.test.ts
+++ b/src/test/suite/livePreview.test.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
-import { window, workspace, ConfigurationTarget, QuickPickItem } from "vscode";
+import { window, QuickPickItem } from "vscode";
 import livePreview from "../../helpers/livePreview";
+import { stub, globalSetting } from "./helpers";
 
 const SECTION = "terminal.integrated.fontSize";
 
@@ -13,50 +14,31 @@ const toValue = (item: SizeItem) => parseInt(item.label.slice(0, -3));
 
 suite("livePreview", () => {
   const realShowQuickPick = window.showQuickPick;
-  let original: number | undefined;
+  const size = globalSetting<number>(SECTION);
 
-  suiteSetup(() => {
-    original = workspace.getConfiguration().inspect(SECTION)?.globalValue as
-      | number
-      | undefined;
-  });
+  suiteSetup(size.capture);
 
   suiteTeardown(async () => {
-    (window as { showQuickPick: typeof window.showQuickPick }).showQuickPick =
-      realShowQuickPick;
-    await workspace
-      .getConfiguration()
-      .update(SECTION, original, ConfigurationTarget.Global);
+    stub(window, "showQuickPick", realShowQuickPick);
+    await size.restore();
   });
 
-  async function setBaseline(value: number) {
-    await workspace
-      .getConfiguration()
-      .update(SECTION, value, ConfigurationTarget.Global);
-  }
-
-  function stubQuickPick(impl: (items: any, options: any) => Promise<any>) {
-    (window as { showQuickPick: any }).showQuickPick = impl;
-  }
-
   test("persists the picked value on accept", async () => {
-    await setBaseline(12);
-    stubQuickPick(async (items) => items[2]); // pick 10-pt
+    await size.set(12);
+    stub(window, "showQuickPick", async (items: any) => items[2]); // pick 10-pt
     await livePreview({ section: SECTION, items: ITEMS, toValue });
-    assert.strictEqual(workspace.getConfiguration().get(SECTION), 10);
+    assert.strictEqual(size.value(), 10);
   });
 
   test("restores the original value on cancel, even after a preview write landed", async () => {
-    await setBaseline(12);
-    stubQuickPick(async (_items, options) => {
+    await size.set(12);
+    stub(window, "showQuickPick", async (_items: any, options: any) => {
       // Simulate a preview hover-write that already hit config, then Escape.
-      await workspace
-        .getConfiguration()
-        .update(SECTION, 25, ConfigurationTarget.Global);
+      await size.set(25);
       options.onDidSelectItem?.(ITEMS[3]);
       return undefined;
     });
     await livePreview({ section: SECTION, items: ITEMS, toValue });
-    assert.strictEqual(workspace.getConfiguration().get(SECTION), 12);
+    assert.strictEqual(size.value(), 12);
   });
 });

--- a/src/test/suite/messages.test.ts
+++ b/src/test/suite/messages.test.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
-import { window, commands, workspace, ConfigurationTarget } from "vscode";
+import { window, commands } from "vscode";
 import { messagesEnabled, showWelcome, showError } from "../../messages";
+import { stub, globalSetting } from "./helpers";
 
 const DISABLE = "disableAllMessages";
 
@@ -8,52 +9,42 @@ suite("messages", () => {
   const realInfo = window.showInformationMessage;
   const realErr = window.showErrorMessage;
   const realExec = commands.executeCommand;
+  const disabled = globalSetting<boolean>(DISABLE, "terminalAllInOne");
+
+  suiteSetup(disabled.capture);
 
   suiteTeardown(async () => {
-    (window as { showInformationMessage: any }).showInformationMessage =
-      realInfo;
-    (window as { showErrorMessage: any }).showErrorMessage = realErr;
-    (commands as { executeCommand: any }).executeCommand = realExec;
-    await workspace
-      .getConfiguration("terminalAllInOne")
-      .update(DISABLE, undefined, ConfigurationTarget.Global);
+    stub(window, "showInformationMessage", realInfo);
+    stub(window, "showErrorMessage", realErr);
+    stub(commands, "executeCommand", realExec);
+    await disabled.restore();
   });
 
-  async function setDisabled(v: boolean | undefined) {
-    await workspace
-      .getConfiguration("terminalAllInOne")
-      .update(DISABLE, v, ConfigurationTarget.Global);
-  }
-
   test("messagesEnabled reflects the disableAllMessages setting", async () => {
-    await setDisabled(true);
+    await disabled.set(true);
     assert.strictEqual(messagesEnabled(), false);
-    await setDisabled(false);
+    await disabled.set(false);
     assert.strictEqual(messagesEnabled(), true);
   });
 
   test("showWelcome opens the README when the button is clicked", async () => {
-    await setDisabled(false);
-    (window as { showInformationMessage: any }).showInformationMessage =
-      async () => "README";
+    await disabled.set(false);
+    stub(window, "showInformationMessage", async () => "README");
     let opened: string | undefined;
-    (commands as { executeCommand: any }).executeCommand = async (
-      cmd: string,
-      arg?: string,
-    ) => {
+    stub(commands, "executeCommand", async (cmd: string, arg?: string) => {
       if (cmd === "extension.open") opened = arg;
-    };
+    });
     await showWelcome();
     assert.strictEqual(opened, "yasht.terminal-all-in-one");
   });
 
   test("showError stays silent when messages are disabled", async () => {
-    await setDisabled(true);
+    await disabled.set(true);
     let called = false;
-    (window as { showErrorMessage: any }).showErrorMessage = () => {
+    stub(window, "showErrorMessage", () => {
       called = true;
       return Promise.resolve(undefined);
-    };
+    });
     showError("boom");
     assert.strictEqual(called, false);
   });

--- a/src/test/suite/runScript.test.ts
+++ b/src/test/suite/runScript.test.ts
@@ -1,15 +1,21 @@
 import assert from "assert";
-import { window, commands, workspace, ConfigurationTarget } from "vscode";
+import { window, commands } from "vscode";
 import { execute, runScript, getScriptsConfig } from "../../commands/runScript";
+import { stub, globalSetting } from "./helpers";
 
 suite("runScript execute", () => {
   const realCreateTerminal = window.createTerminal;
   const realExecuteCommand = commands.executeCommand;
+  const autoRun = globalSetting<boolean>(
+    "script.disableAutoRun",
+    "terminalAllInOne",
+  );
   let sequence: string | undefined;
   let originalActiveTerminal: PropertyDescriptor | undefined;
   let activeTerminalRedefined = false;
 
   suiteSetup(() => {
+    autoRun.capture();
     // No real terminals are ever created in tests, so activeTerminal stays undefined and execute() takes the createTerminal path.
     originalActiveTerminal = Object.getOwnPropertyDescriptor(
       window,
@@ -27,12 +33,8 @@ suite("runScript execute", () => {
   });
 
   suiteTeardown(async () => {
-    (
-      window as { createTerminal: typeof window.createTerminal }
-    ).createTerminal = realCreateTerminal;
-    (
-      commands as { executeCommand: typeof commands.executeCommand }
-    ).executeCommand = realExecuteCommand;
+    stub(window, "createTerminal", realCreateTerminal);
+    stub(commands, "executeCommand", realExecuteCommand);
     if (activeTerminalRedefined) {
       if (originalActiveTerminal) {
         Object.defineProperty(window, "activeTerminal", originalActiveTerminal);
@@ -40,66 +42,52 @@ suite("runScript execute", () => {
         delete (window as { activeTerminal?: unknown }).activeTerminal;
       }
     }
-    await workspace
-      .getConfiguration("terminalAllInOne")
-      .update("script.disableAutoRun", undefined, ConfigurationTarget.Global);
+    await autoRun.restore();
   });
 
   setup(() => {
     sequence = undefined;
-    (window as { createTerminal: any }).createTerminal = () =>
-      ({ show() {} }) as never;
-    (commands as { executeCommand: any }).executeCommand = (
-      command: string,
-      args?: { text?: string },
-    ) => {
-      if (command === "workbench.action.terminal.sendSequence") {
-        sequence = args?.text;
-      }
-      return Promise.resolve();
-    };
+    stub(window, "createTerminal", () => ({ show() {} }) as never);
+    stub(
+      commands,
+      "executeCommand",
+      (command: string, args?: { text?: string }) => {
+        if (command === "workbench.action.terminal.sendSequence") {
+          sequence = args?.text;
+        }
+        return Promise.resolve();
+      },
+    );
   });
 
   test("joins array commands with && and runs them (trailing carriage return)", async () => {
-    await workspace
-      .getConfiguration("terminalAllInOne")
-      .update("script.disableAutoRun", false, ConfigurationTarget.Global);
+    await autoRun.set(false);
     await execute({ name: "Multi", script: ["a", "b", "c"] });
     assert.strictEqual(sequence, "a && b && c\r");
   });
 
   test("disableAutoRun inserts the command without running it (no carriage return)", async () => {
-    await workspace
-      .getConfiguration("terminalAllInOne")
-      .update("script.disableAutoRun", true, ConfigurationTarget.Global);
+    await autoRun.set(true);
     await execute({ name: "Solo", script: "echo hi" });
     assert.strictEqual(sequence, "echo hi");
   });
 });
 
 suite("getScriptsConfig", () => {
-  suiteTeardown(async () => {
-    await workspace
-      .getConfiguration("terminalAllInOne")
-      .update("scripts", undefined, ConfigurationTarget.Global);
-  });
+  const scripts = globalSetting<unknown[]>("scripts", "terminalAllInOne");
+
+  suiteTeardown(() => scripts.set(undefined));
 
   test("keeps valid entries and drops malformed ones", async () => {
-    await workspace
-      .getConfiguration("terminalAllInOne")
-      .update(
-        "scripts",
-        [
-          { name: "ok", script: "echo hi" },
-          { name: "arr", script: ["a", "b"] },
-          { name: "missingScript" },
-          { script: "missingName" },
-          "not an object",
-          null,
-          { name: 1, script: "badName" },
-        ],
-        ConfigurationTarget.Global,
-      );
+    await scripts.set([
+      { name: "ok", script: "echo hi" },
+      { name: "arr", script: ["a", "b"] },
+      { name: "missingScript" },
+      { script: "missingName" },
+      "not an object",
+      null,
+      { name: 1, script: "badName" },
+    ]);
     assert.deepStrictEqual(getScriptsConfig(), [
       { name: "ok", script: "echo hi" },
       { name: "arr", script: ["a", "b"] },
@@ -107,9 +95,7 @@ suite("getScriptsConfig", () => {
   });
 
   test("returns [] when scripts is unset", async () => {
-    await workspace
-      .getConfiguration("terminalAllInOne")
-      .update("scripts", undefined, ConfigurationTarget.Global);
+    await scripts.set(undefined);
     assert.deepStrictEqual(getScriptsConfig(), []);
   });
 });
@@ -119,49 +105,40 @@ suite("runScript routing", () => {
   const realShowWarningMessage = window.showWarningMessage;
   const realExecuteCommand = commands.executeCommand;
   const realCreateTerminal = window.createTerminal;
+  const scripts = globalSetting<unknown[]>("scripts", "terminalAllInOne");
   let sequence: string | undefined;
   let warning: string | undefined;
 
   suiteTeardown(async () => {
-    (window as { showQuickPick: any }).showQuickPick = realShowQuickPick;
-    (window as { showWarningMessage: any }).showWarningMessage =
-      realShowWarningMessage;
-    (commands as { executeCommand: any }).executeCommand = realExecuteCommand;
-    (window as { createTerminal: any }).createTerminal = realCreateTerminal;
-    await workspace
-      .getConfiguration("terminalAllInOne")
-      .update("scripts", undefined, ConfigurationTarget.Global);
+    stub(window, "showQuickPick", realShowQuickPick);
+    stub(window, "showWarningMessage", realShowWarningMessage);
+    stub(commands, "executeCommand", realExecuteCommand);
+    stub(window, "createTerminal", realCreateTerminal);
+    await scripts.set(undefined);
   });
 
   setup(() => {
     sequence = undefined;
     warning = undefined;
-    (window as { createTerminal: any }).createTerminal = () => ({ show() {} });
-    (window as { showWarningMessage: any }).showWarningMessage = (
-      msg: string,
-    ) => {
+    stub(window, "createTerminal", () => ({ show() {} }));
+    stub(window, "showWarningMessage", (msg: string) => {
       warning = msg;
       return Promise.resolve(undefined);
-    };
-    (commands as { executeCommand: any }).executeCommand = (
-      command: string,
-      args?: { text?: string },
-    ) => {
-      if (command === "workbench.action.terminal.sendSequence") {
-        sequence = args?.text;
-      }
-      return Promise.resolve();
-    };
+    });
+    stub(
+      commands,
+      "executeCommand",
+      (command: string, args?: { text?: string }) => {
+        if (command === "workbench.action.terminal.sendSequence") {
+          sequence = args?.text;
+        }
+        return Promise.resolve();
+      },
+    );
   });
 
-  async function setScripts(scripts: unknown[]) {
-    await workspace
-      .getConfiguration("terminalAllInOne")
-      .update("scripts", scripts, ConfigurationTarget.Global);
-  }
-
   test("a valid index runs that script", async () => {
-    await setScripts([
+    await scripts.set([
       { name: "first", script: "echo one" },
       { name: "second", script: "echo two" },
     ]);
@@ -170,25 +147,24 @@ suite("runScript routing", () => {
   });
 
   test("an out-of-range index warns and runs nothing", async () => {
-    await setScripts([{ name: "only", script: "echo one" }]);
+    await scripts.set([{ name: "only", script: "echo one" }]);
     await runScript(5);
     assert.strictEqual(sequence, undefined);
     assert.strictEqual(warning, "No script has been defined for that index");
   });
 
   test("no scripts and no index warns", async () => {
-    await setScripts([]);
+    await scripts.set([]);
     await runScript();
     assert.strictEqual(warning, "No scripts have been defined");
   });
 
   test("the picker runs the selected script", async () => {
-    await setScripts([
+    await scripts.set([
       { name: "first", script: "echo one" },
       { name: "second", script: "echo two" },
     ]);
-    (window as { showQuickPick: any }).showQuickPick = async (items: any[]) =>
-      items[1];
+    stub(window, "showQuickPick", async (items: any[]) => items[1]);
     await runScript();
     assert.strictEqual(sequence, "echo two\r");
   });


### PR DESCRIPTION
Closes #444. Adds `src/test/suite/helpers.ts` exporting three test utilities: `tick`, a `stub()` setter for swapping/restoring `window`/`commands` methods, and `globalSetting()` which owns the capture/set/read/restore lifecycle for a global-scoped setting. Adopts these across the 8 config/stub suites, deleting their local `set*`/`stub*`/`colorsValue` helpers and collapsing each repeated three-line `getConfiguration().update(..., ConfigurationTarget.Global)` into a single call. Assertions that previously mixed `.get()` (effective) and `.inspect().globalValue` now read uniformly through `value()`, which is equivalent since the test host only ever writes at Global scope. Net −349/+215 across the edited suites; all 55 tests, typecheck, and lint still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure with new shared helper utilities for managing extension settings and mocking APIs, improving test consistency and reducing code duplication across the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->