### PR TITLE
Refresh extension metadata: themes-first positioning and cleaner tags

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -60,7 +60,7 @@ body:
     attributes:
       label: Extension version
       description: Shown next to "Terminal All In One" in the Extensions view.
-      placeholder: "1.12.2"
+      placeholder: "2.0.0"
     validations:
       required: true
   - type: input
@@ -68,7 +68,7 @@ body:
     attributes:
       label: VS Code version
       description: From Help → About, or run `code --version`.
-      placeholder: "1.85.0"
+      placeholder: "1.96.0"
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <b>Terminal All In One</b>
 </h1>
 
-<p align="center"><strong>Save and run terminal scripts, apply 100+ terminal themes, and control your terminal with keybindings</strong></p>
+<p align="center"><strong>Apply 100+ terminal themes, save and run terminal scripts, and control your terminal with keybindings</strong></p>
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/YashTotale/terminal-all-in-one/master/demos/ChooseATerminalTheme.gif" alt="Choosing a terminal theme" width="600">

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "keywords": [
     "terminal",
+    "terminal themes",
+    "scripts",
     "keybindings",
     "shell",
-    "keymap",
-    "theme",
-    "script"
+    "base16"
   ],
   "name": "terminal-all-in-one",
   "displayName": "Terminal All In One",
-  "description": "Supercharge your terminal with themes, commands, scripts, and key bindings!",
+  "description": "Apply 100+ terminal themes, save and run terminal scripts, and control your terminal with keybindings",
   "version": "1.12.2",
   "homepage": "https://marketplace.visualstudio.com/items?itemName=yasht.terminal-all-in-one",
   "license": "MIT",
@@ -25,9 +25,10 @@
   "bugs": {
     "url": "https://github.com/YashTotale/terminal-all-in-one/issues"
   },
+  "qna": "https://github.com/YashTotale/terminal-all-in-one/discussions/categories/q-a",
   "icon": "images/terminal-icon.jpg",
   "author": {
-    "name": "Yash T"
+    "name": "Yash Totale"
   },
   "main": "./dist/extension",
   "engines": {
@@ -36,7 +37,6 @@
   },
   "packageManager": "pnpm@11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912",
   "categories": [
-    "Other",
     "Keymaps",
     "Themes"
   ],


### PR DESCRIPTION
Reorders the marketplace `description` and README tagline to lead with **"Apply 100+ terminal themes"**, putting the strongest hook in the search-result preview and dropping the vague "Supercharge"/"commands" framing. De-duplicates the marketplace tags (drops `keymap`, refines `theme` → `terminal themes`, adds `base16`) so each keyword pulls its own weight. Also routes the marketplace Q&A tab to GitHub Discussions via `qna`, removes the redundant `Other` category, uses the author's full name, and refreshes the bug-report version placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)