### PR TITLE
Add one-button release pipeline and v2 release prep

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -60,3 +60,14 @@ jobs:
       - name: Show Extension Data
         if: runner.os == 'Linux' && matrix.node-version == '22.x'
         run: pnpm run show-data
+
+  lint-workflows:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      # actionlint validates workflow YAML/expressions and runs shellcheck over run: blocks.
+      - name: Lint GitHub Actions workflows
+        run: docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest -color

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Test Scripts
+        run: pnpm run test:scripts
+
       - name: Build Project
         run: pnpm run build
 

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -67,7 +67,9 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       # actionlint validates workflow YAML/expressions and runs shellcheck over run: blocks.
       - name: Lint GitHub Actions workflows
-        run: docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:latest -color
+        run: docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:1.7.12 -color

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,16 +69,21 @@ jobs:
           pnpm exec vsce show "$EXTENSION_ID" --json > .release/marketplace.json
           published=$(node -p "require('./.release/marketplace.json').versions[0].version")
           newer=$(printf '%s\n%s\n' "$current" "$published" | sort -V | tail -1)
+          asset="terminal-all-in-one-$current.vsix"
+          release_complete=false
+          if gh release view "v$current" --json assets --jq '.assets[].name' 2>/dev/null | grep -qx "$asset"; then
+            release_complete=true
+          fi
           if [ "$published" != "$current" ] && [ "$newer" = "$published" ]; then
             echo "::error::Marketplace has v$published but master is at v$current with no v$published tag. A prior release published without pushing its commit/tag; reconcile v$published manually (push its commit + tag and create the Release) before re-running."
             exit 1
-          elif git rev-parse -q --verify "refs/tags/v$current" >/dev/null && ! gh release view "v$current" >/dev/null 2>&1; then
+          elif git rev-parse -q --verify "refs/tags/v$current" >/dev/null && [ "$release_complete" = false ]; then
             if [ "$(git rev-parse HEAD)" != "$(git rev-parse "refs/tags/v$current^{commit}")" ]; then
-              echo "::error::Tag v$current exists without a Release, but HEAD has moved past the tagged commit. Re-run from the tagged commit so the Release asset matches the published build, or reconcile manually."
+              echo "::error::Tag v$current exists but its Release is missing or has no asset, and HEAD has moved past the tagged commit. Re-run from the tagged commit so the Release asset matches the published build, or reconcile manually."
               exit 1
             fi
             version="$current"
-            echo "Finalize recovery: tag v$current exists without a Release; HEAD matches the tag."
+            echo "Finalize recovery: v$current is tagged but its Release is missing or has no $asset asset; HEAD matches the tag."
           else
             version=$(node -e "const [a,b,c]=process.argv[1].split('.').map(Number); const t=process.argv[2]; console.log((t==='major'?[a+1,0,0]:t==='minor'?[a,b+1,0]:[a,b,c+1]).join('.'))" "$current" "${{ inputs.bump }}")
             echo "Normal release: v$current -> v$version."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,162 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+        required: true
+      dry_run:
+        description: Rehearse without publishing
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    environment: release
+    env:
+      EXTENSION_ID: yasht.terminal-all-in-one
+      PUBLISHER: yasht
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify marketplace token
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: pnpm exec vsce verify-pat "$PUBLISHER"
+
+      - name: Determine release mode
+        id: mode
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          current=$(node -p "require('./package.json').version")
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          tag_exists=false
+          if git rev-parse -q --verify "refs/tags/v$current" >/dev/null; then
+            tag_exists=true
+          fi
+          release_exists=false
+          if gh release view "v$current" >/dev/null 2>&1; then
+            release_exists=true
+          fi
+          if [ "$tag_exists" = true ] && [ "$release_exists" = false ]; then
+            echo "recovery=true" >> "$GITHUB_OUTPUT"
+            echo "Recovery: tag v$current exists with no Release; finalizing without a bump."
+          else
+            echo "recovery=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Gate (build, test, lint)
+        run: |
+          pnpm run build
+          pnpm run test:scripts
+          pnpm run test:compile
+          xvfb-run -a pnpm test
+          pnpm run lint
+
+      - name: Bump version
+        id: bump
+        if: steps.mode.outputs.recovery == 'false'
+        run: |
+          pnpm version "${{ inputs.bump }}" --no-git-tag-version
+          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve version
+        id: resolve
+        run: |
+          if [ "${{ steps.mode.outputs.recovery }}" = "true" ]; then
+            version="${{ steps.mode.outputs.current }}"
+          else
+            version="${{ steps.bump.outputs.version }}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "vsix=terminal-all-in-one-$version.vsix" >> "$GITHUB_OUTPUT"
+
+      - name: Build release notes
+        run: |
+          mkdir -p .release
+          if [ "${{ steps.mode.outputs.recovery }}" = "true" ]; then
+            node scripts/promote-changelog.mjs notes "${{ steps.resolve.outputs.version }}" > .release/notes.md
+          else
+            node scripts/promote-changelog.mjs promote "${{ steps.resolve.outputs.version }}" "$(date -u +%Y-%m-%d)" > .release/notes.md
+          fi
+
+      - name: Package extension
+        run: pnpm exec vsce package --no-dependencies -o "${{ steps.resolve.outputs.vsix }}"
+
+      - name: Publish to Marketplace
+        if: ${{ !inputs.dry_run }}
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+          VSIX: ${{ steps.resolve.outputs.vsix }}
+        run: |
+          pnpm exec vsce show "$EXTENSION_ID" --json > .release/marketplace.json
+          already=$(node -p "require('./.release/marketplace.json').versions.some((v) => v.version === process.argv[1])" "$VERSION")
+          if [ "$already" = "true" ]; then
+            echo "v$VERSION is already on the Marketplace; skipping publish."
+          else
+            pnpm exec vsce publish --packagePath "$VSIX"
+          fi
+
+      - name: Commit, tag, and push
+        if: ${{ !inputs.dry_run }}
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json CHANGELOG.md
+          if ! git diff --cached --quiet; then
+            git commit -m "Release v$VERSION [skip ci]"
+          fi
+          if ! git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            git tag "v$VERSION"
+          fi
+          git push --follow-tags origin HEAD:master
+
+      - name: Create GitHub Release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+          VSIX: ${{ steps.resolve.outputs.vsix }}
+        run: |
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            gh release upload "v$VERSION" "$VSIX" --clobber
+          else
+            gh release create "v$VERSION" --title "v$VERSION" --notes-file .release/notes.md "$VSIX"
+          fi
+
+      - name: Upload dry-run artifact
+        if: ${{ inputs.dry_run }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.resolve.outputs.vsix }}
+          path: ${{ steps.resolve.outputs.vsix }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,28 +50,6 @@ jobs:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: pnpm exec vsce verify-pat "$PUBLISHER"
 
-      - name: Determine release mode
-        id: mode
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          current=$(node -p "require('./package.json').version")
-          echo "current=$current" >> "$GITHUB_OUTPUT"
-          tag_exists=false
-          if git rev-parse -q --verify "refs/tags/v$current" >/dev/null; then
-            tag_exists=true
-          fi
-          release_exists=false
-          if gh release view "v$current" >/dev/null 2>&1; then
-            release_exists=true
-          fi
-          if [ "$tag_exists" = true ] && [ "$release_exists" = false ]; then
-            echo "recovery=true" >> "$GITHUB_OUTPUT"
-            echo "Recovery: tag v$current exists with no Release; finalizing without a bump."
-          else
-            echo "recovery=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Gate (build, test, lint)
         run: |
           pnpm run build
@@ -80,44 +58,52 @@ jobs:
           xvfb-run -a pnpm test
           pnpm run lint
 
-      - name: Bump version
-        id: bump
-        if: steps.mode.outputs.recovery == 'false'
+      - name: Determine release plan
+        id: plan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pnpm version "${{ inputs.bump }}" --no-git-tag-version
-          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve version
-        id: resolve
-        run: |
-          if [ "${{ steps.mode.outputs.recovery }}" = "true" ]; then
-            version="${{ steps.mode.outputs.current }}"
+          mkdir -p .release
+          current=$(node -p "require('./package.json').version")
+          pnpm exec vsce show "$EXTENSION_ID" --json > .release/marketplace.json
+          published=$(node -p "require('./.release/marketplace.json').versions[0].version")
+          newer=$(printf '%s\n%s\n' "$current" "$published" | sort -V | tail -1)
+          if [ "$published" != "$current" ] && [ "$newer" = "$published" ]; then
+            version="$published"
+            echo "Orphan recovery: Marketplace has v$published but master is at v$current; finalizing v$published."
+          elif git rev-parse -q --verify "refs/tags/v$current" >/dev/null && ! gh release view "v$current" >/dev/null 2>&1; then
+            version="$current"
+            echo "Finalize recovery: tag v$current exists without a Release."
           else
-            version="${{ steps.bump.outputs.version }}"
+            version=$(node -e "const [a,b,c]=process.argv[1].split('.').map(Number); const t=process.argv[2]; console.log((t==='major'?[a+1,0,0]:t==='minor'?[a,b+1,0]:[a,b,c+1]).join('.'))" "$current" "${{ inputs.bump }}")
+            echo "Normal release: v$current -> v$version."
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "vsix=terminal-all-in-one-$version.vsix" >> "$GITHUB_OUTPUT"
 
-      - name: Build release notes
+      - name: Set version and changelog
+        env:
+          VERSION: ${{ steps.plan.outputs.version }}
         run: |
-          mkdir -p .release
-          if [ "${{ steps.mode.outputs.recovery }}" = "true" ]; then
-            node scripts/promote-changelog.mjs notes "${{ steps.resolve.outputs.version }}" > .release/notes.md
+          if [ "$VERSION" != "$(node -p "require('./package.json').version")" ]; then
+            pnpm version "$VERSION" --no-git-tag-version
+          fi
+          if node scripts/promote-changelog.mjs notes "$VERSION" > .release/notes.md 2>/dev/null; then
+            echo "Changelog already lists v$VERSION; reusing its notes."
           else
-            node scripts/promote-changelog.mjs promote "${{ steps.resolve.outputs.version }}" "$(date -u +%Y-%m-%d)" > .release/notes.md
+            node scripts/promote-changelog.mjs promote "$VERSION" "$(date -u +%Y-%m-%d)" > .release/notes.md
           fi
 
       - name: Package extension
-        run: pnpm exec vsce package --no-dependencies -o "${{ steps.resolve.outputs.vsix }}"
+        run: pnpm exec vsce package --no-dependencies -o "${{ steps.plan.outputs.vsix }}"
 
       - name: Publish to Marketplace
         if: ${{ !inputs.dry_run }}
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-          VERSION: ${{ steps.resolve.outputs.version }}
-          VSIX: ${{ steps.resolve.outputs.vsix }}
+          VERSION: ${{ steps.plan.outputs.version }}
+          VSIX: ${{ steps.plan.outputs.vsix }}
         run: |
-          pnpm exec vsce show "$EXTENSION_ID" --json > .release/marketplace.json
           already=$(node -p "require('./.release/marketplace.json').versions.some((v) => v.version === process.argv[1])" "$VERSION")
           if [ "$already" = "true" ]; then
             echo "v$VERSION is already on the Marketplace; skipping publish."
@@ -128,7 +114,7 @@ jobs:
       - name: Commit, tag, and push
         if: ${{ !inputs.dry_run }}
         env:
-          VERSION: ${{ steps.resolve.outputs.version }}
+          VERSION: ${{ steps.plan.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -145,8 +131,8 @@ jobs:
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.resolve.outputs.version }}
-          VSIX: ${{ steps.resolve.outputs.vsix }}
+          VERSION: ${{ steps.plan.outputs.version }}
+          VSIX: ${{ steps.plan.outputs.vsix }}
         run: |
           if gh release view "v$VERSION" >/dev/null 2>&1; then
             gh release upload "v$VERSION" "$VSIX" --clobber
@@ -158,5 +144,5 @@ jobs:
         if: ${{ inputs.dry_run }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.resolve.outputs.vsix }}
-          path: ${{ steps.resolve.outputs.vsix }}
+          name: ${{ steps.plan.outputs.vsix }}
+          path: ${{ steps.plan.outputs.vsix }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
             fi
           fi
           release_complete=false
-          if gh release view "v$current" --json assets --jq '.assets[].name' 2>/dev/null | grep -qx "$asset"; then
+          if gh release view "v$current" --json assets --jq '.assets[].name' 2>/dev/null | grep -Fqx "$asset"; then
             release_complete=true
           fi
           CURRENT="$current" PUBLISHED="$published" BUMP="${{ inputs.bump }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,28 +68,23 @@ jobs:
           current=$(node -p "require('./package.json').version")
           pnpm exec vsce show "$EXTENSION_ID" --json > .release/marketplace.json
           published=$(node -p "require('./.release/marketplace.json').versions[0].version")
-          newer=$(printf '%s\n%s\n' "$current" "$published" | sort -V | tail -1)
           asset="terminal-all-in-one-$current.vsix"
+          tag_exists=false
+          head_matches_tag=false
+          if git rev-parse -q --verify "refs/tags/v$current^{commit}" >/dev/null; then
+            tag_exists=true
+            if [ "$(git rev-parse HEAD)" = "$(git rev-parse "refs/tags/v$current^{commit}")" ]; then
+              head_matches_tag=true
+            fi
+          fi
           release_complete=false
           if gh release view "v$current" --json assets --jq '.assets[].name' 2>/dev/null | grep -qx "$asset"; then
             release_complete=true
           fi
-          if [ "$published" != "$current" ] && [ "$newer" = "$published" ]; then
-            echo "::error::Marketplace has v$published but master is at v$current with no v$published tag. A prior release published without pushing its commit/tag; reconcile v$published manually (push its commit + tag and create the Release) before re-running."
-            exit 1
-          elif git rev-parse -q --verify "refs/tags/v$current" >/dev/null && [ "$release_complete" = false ]; then
-            if [ "$(git rev-parse HEAD)" != "$(git rev-parse "refs/tags/v$current^{commit}")" ]; then
-              echo "::error::Tag v$current exists but its Release is missing or has no asset, and HEAD has moved past the tagged commit. Re-run from the tagged commit so the Release asset matches the published build, or reconcile manually."
-              exit 1
-            fi
-            version="$current"
-            echo "Finalize recovery: v$current is tagged but its Release is missing or has no $asset asset; HEAD matches the tag."
-          else
-            version=$(node -e "const [a,b,c]=process.argv[1].split('.').map(Number); const t=process.argv[2]; console.log((t==='major'?[a+1,0,0]:t==='minor'?[a,b+1,0]:[a,b,c+1]).join('.'))" "$current" "${{ inputs.bump }}")
-            echo "Normal release: v$current -> v$version."
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "vsix=terminal-all-in-one-$version.vsix" >> "$GITHUB_OUTPUT"
+          CURRENT="$current" PUBLISHED="$published" BUMP="${{ inputs.bump }}" \
+            TAG_EXISTS="$tag_exists" HEAD_MATCHES_TAG="$head_matches_tag" \
+            RELEASE_COMPLETE="$release_complete" \
+            node scripts/release-plan.mjs
 
       - name: Set version and changelog
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -69,11 +70,15 @@ jobs:
           published=$(node -p "require('./.release/marketplace.json').versions[0].version")
           newer=$(printf '%s\n%s\n' "$current" "$published" | sort -V | tail -1)
           if [ "$published" != "$current" ] && [ "$newer" = "$published" ]; then
-            version="$published"
-            echo "Orphan recovery: Marketplace has v$published but master is at v$current; finalizing v$published."
+            echo "::error::Marketplace has v$published but master is at v$current with no v$published tag. A prior release published without pushing its commit/tag; reconcile v$published manually (push its commit + tag and create the Release) before re-running."
+            exit 1
           elif git rev-parse -q --verify "refs/tags/v$current" >/dev/null && ! gh release view "v$current" >/dev/null 2>&1; then
+            if [ "$(git rev-parse HEAD)" != "$(git rev-parse "refs/tags/v$current^{commit}")" ]; then
+              echo "::error::Tag v$current exists without a Release, but HEAD has moved past the tagged commit. Re-run from the tagged commit so the Release asset matches the published build, or reconcile manually."
+              exit 1
+            fi
             version="$current"
-            echo "Finalize recovery: tag v$current exists without a Release."
+            echo "Finalize recovery: tag v$current exists without a Release; HEAD matches the tag."
           else
             version=$(node -e "const [a,b,c]=process.argv[1].split('.').map(Number); const t=process.argv[2]; console.log((t==='major'?[a+1,0,0]:t==='minor'?[a,b+1,0]:[a,b,c+1]).join('.'))" "$current" "${{ inputs.bump }}")
             echo "Normal release: v$current -> v$version."
@@ -115,6 +120,7 @@ jobs:
         if: ${{ !inputs.dry_run }}
         env:
           VERSION: ${{ steps.plan.outputs.version }}
+          PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -125,7 +131,7 @@ jobs:
           if ! git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
             git tag -a "v$VERSION" -m "v$VERSION"
           fi
-          git push --follow-tags origin HEAD:master
+          git push --follow-tags "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:master
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
           if ! git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
             git tag -a "v$VERSION" -m "v$VERSION"
           fi
-          git push --follow-tags "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:master
+          git push --atomic --follow-tags "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:master
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
             git commit -m "Release v$VERSION [skip ci]"
           fi
           if ! git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
-            git tag "v$VERSION"
+            git tag -a "v$VERSION" -m "v$VERSION"
           fi
           git push --follow-tags origin HEAD:master
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ out
 
 # Raw demo recordings; only the generated GIFs are committed.
 demos/*.mp4
+
+# Local brainstorming specs & implementation plans
+docs/superpowers/specs/
+docs/superpowers/plans/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ demos/*.mp4
 # Local brainstorming specs & implementation plans
 docs/superpowers/specs/
 docs/superpowers/plans/
+
+# Release workflow scratch dir (created by .github/workflows/release.yml)
+.release/

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -9,3 +9,6 @@ coverage/
 dist/
 out/
 build/
+
+# local planning docs
+docs/superpowers/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -16,6 +16,10 @@ node_modules/
 # Demos (referenced via raw GitHub URLs, never loaded from the package)
 demos/
 
+# Dev tooling & local docs (never shipped in the extension)
+scripts/
+docs/
+
 # Misc
 **/*.map
 .*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format of this Change Log is based on [Keep a Changelog](http://keepachangel
 
 #### Added
 
-- Option to insert a script's command into the terminal without running it (`terminalAllInOne.script.disableAutoRun`). Closes [#414](https://github.com/YashTotale/terminal-all-in-one/issues/414).
+- Option to insert a script's command into the terminal without running it (`terminalAllInOne.script.disableAutoRun`).
 
 #### Changed
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,13 @@
 
 ## Commands & Keybindings
 
-Press `cmd+i` (macOS) or `ctrl+i` (Windows/Linux), then the key below — toggling the terminal is the one exception (no `i`). Every command is also available from the Command Palette under **Terminal All In One**. Set `terminalAllInOne.disableAllKeybindings` to `true` to turn the keybindings off.
+Press `cmd+i` (macOS) or `ctrl+i` (Windows/Linux), then the key below. Every command is also available from the Command Palette under **Terminal All In One**. Set `terminalAllInOne.disableAllKeybindings` to `true` to turn the keybindings off.
 
 | Keybinding             | Command                   | Description                                        |
 | ---------------------- | ------------------------- | -------------------------------------------------- |
 | `cmd/ctrl+i t`         | Choose Theme              | Live-preview and apply one of 100+ terminal themes |
 | `cmd/ctrl+i enter`     | Run Script                | Pick a saved script to run                         |
 | `cmd/ctrl+i 0`–`9`     | Run Script                | Run one of your first 10 saved scripts directly    |
-| `` cmd/ctrl+` ``       | Toggle Terminal           | Show or hide the integrated terminal               |
 | `cmd/ctrl+i m`         | Toggle Maximized Terminal | Maximize or restore the terminal panel             |
 | `cmd/ctrl+i c`         | Create New Terminal       | Open a new terminal instance                       |
 | `cmd/ctrl+i d`         | Delete Current Terminal   | Close the active terminal                          |

--- a/package.json
+++ b/package.json
@@ -481,15 +481,16 @@
   },
   "scripts": {
     "build": "node esbuild.js --production",
+    "vscode:prepublish": "pnpm run build",
     "build:dev": "node esbuild.js",
     "watch": "node esbuild.js --watch",
     "typecheck": "tsc --noEmit -p ./",
     "test:compile": "tsc -p ./",
     "pretest": "pnpm run test:compile && pnpm run build:dev",
     "test": "vscode-test",
+    "test:scripts": "node --test \"scripts/**/*.test.mjs\"",
     "lint": "eslint . && prettier --check . && markdownlint \"**/*.md\"",
     "lint:staged": "lint-staged",
-    "deploy": "pnpm run build && vsce publish --no-dependencies",
     "show-data": "vsce show yasht.terminal-all-in-one",
     "prepare": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -491,6 +491,7 @@
     "test:scripts": "node --test \"scripts/**/*.test.mjs\"",
     "lint": "eslint . && prettier --check . && markdownlint \"**/*.md\"",
     "lint:staged": "lint-staged",
+    "lint:workflows": "docker run --rm -v \"$PWD:/repo\" --workdir /repo rhysd/actionlint:latest -color",
     "show-data": "vsce show yasht.terminal-all-in-one",
     "prepare": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -491,7 +491,7 @@
     "test:scripts": "node --test \"scripts/**/*.test.mjs\"",
     "lint": "eslint . && prettier --check . && markdownlint \"**/*.md\"",
     "lint:staged": "lint-staged",
-    "lint:workflows": "docker run --rm -v \"$PWD:/repo\" --workdir /repo rhysd/actionlint:latest -color",
+    "lint:workflows": "docker run --rm -v \"$PWD:/repo\" --workdir /repo rhysd/actionlint:1.7.12 -color",
     "show-data": "vsce show yasht.terminal-all-in-one",
     "prepare": "husky"
   },

--- a/scripts/promote-changelog.mjs
+++ b/scripts/promote-changelog.mjs
@@ -1,0 +1,77 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+const CHANGELOG_PATH = "CHANGELOG.md";
+
+// Body of the "### [<version>]" section: lines until the next "### [" heading, with thematic breaks (---) and surrounding whitespace stripped. Returns null if the heading is absent.
+export function extractNotes(content, version) {
+  const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const headingRe = new RegExp(`^### \\[${escaped}\\]`);
+  const lines = content.split("\n");
+  const start = lines.findIndex((line) => headingRe.test(line));
+  if (start === -1) return null;
+  const body = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^### \[/.test(lines[i])) break;
+    body.push(lines[i]);
+  }
+  return body
+    .join("\n")
+    .replace(/^\s*-{3,}\s*$/gm, "")
+    .trim();
+}
+
+// Promote "### [Unreleased]" to "### [<version>] - (<date>)" and open a fresh empty Unreleased section above it. Returns the rewritten file and the released notes. Throws if there is nothing to release.
+export function promote(content, version, date) {
+  const notes = extractNotes(content, "Unreleased");
+  if (notes === null) {
+    throw new Error("No ### [Unreleased] section found in CHANGELOG.md");
+  }
+  if (notes === "") {
+    throw new Error(
+      "The ### [Unreleased] section is empty — nothing to release",
+    );
+  }
+  const promoted = content.replace(
+    "### [Unreleased]",
+    `### [Unreleased]\n\n---\n\n### [${version}] - (${date})`,
+  );
+  return { promoted, notes };
+}
+
+async function main() {
+  const [mode, version, date] = process.argv.slice(2);
+  const content = await readFile(CHANGELOG_PATH, "utf8");
+
+  if (mode === "promote") {
+    if (!version || !date) {
+      throw new Error("Usage: promote-changelog.mjs promote <version> <date>");
+    }
+    const { promoted, notes } = promote(content, version, date);
+    await writeFile(CHANGELOG_PATH, promoted);
+    process.stdout.write(notes);
+    return;
+  }
+
+  if (mode === "notes") {
+    if (!version) {
+      throw new Error("Usage: promote-changelog.mjs notes <version>");
+    }
+    const notes = extractNotes(content, version);
+    if (notes === null) {
+      throw new Error(`No ### [${version}] section found in CHANGELOG.md`);
+    }
+    process.stdout.write(notes);
+    return;
+  }
+
+  throw new Error(`Unknown mode "${mode}" (expected "promote" or "notes")`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/promote-changelog.mjs
+++ b/scripts/promote-changelog.mjs
@@ -4,7 +4,7 @@ import process from "node:process";
 
 const CHANGELOG_PATH = "CHANGELOG.md";
 
-// Body of the "### [<version>]" section: lines until the next "### [" heading, with thematic breaks (---) and surrounding whitespace stripped. Returns null if the heading is absent.
+// Body of the "### [<version>]" section: lines until the next "### [" heading, with the trailing --- separator and surrounding whitespace stripped. Returns null if the heading is absent.
 export function extractNotes(content, version) {
   const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const headingRe = new RegExp(`^### \\[${escaped}\\]`);
@@ -18,7 +18,7 @@ export function extractNotes(content, version) {
   }
   return body
     .join("\n")
-    .replace(/^\s*-{3,}\s*$/gm, "")
+    .replace(/\n\s*-{3,}\s*$/, "")
     .trim();
 }
 

--- a/scripts/promote-changelog.test.mjs
+++ b/scripts/promote-changelog.test.mjs
@@ -1,0 +1,87 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extractNotes, promote } from "./promote-changelog.mjs";
+
+const SAMPLE = [
+  "## _Terminal All In One_ Change Log",
+  "",
+  "---",
+  "",
+  "### [Unreleased]",
+  "",
+  "#### Added",
+  "",
+  "- A shiny new option.",
+  "",
+  "#### Fixed",
+  "",
+  "- A pesky bug.",
+  "",
+  "---",
+  "",
+  "### [1.12.2] - (2024-03-17)",
+  "",
+  "#### Changed",
+  "",
+  "- README header",
+  "",
+].join("\n");
+
+test("extractNotes returns a section body without heading or rules", () => {
+  assert.equal(
+    extractNotes(SAMPLE, "1.12.2"),
+    "#### Changed\n\n- README header",
+  );
+});
+
+test("extractNotes returns null for a missing section", () => {
+  assert.equal(extractNotes(SAMPLE, "9.9.9"), null);
+});
+
+test("promote moves Unreleased content under a dated version heading", () => {
+  const { promoted } = promote(SAMPLE, "2.0.0", "2026-06-03");
+  assert.match(promoted, /### \[2\.0\.0\] - \(2026-06-03\)/);
+  assert.match(promoted, /### \[2\.0\.0\][\s\S]*- A shiny new option\./);
+});
+
+test("promote opens a fresh empty Unreleased section above the new version", () => {
+  const { promoted } = promote(SAMPLE, "2.0.0", "2026-06-03");
+  assert.equal(extractNotes(promoted, "Unreleased"), "");
+  assert.ok(
+    promoted.indexOf("### [Unreleased]") < promoted.indexOf("### [2.0.0]"),
+  );
+});
+
+test("promote returns the released notes (no date line, no rules)", () => {
+  const { notes } = promote(SAMPLE, "2.0.0", "2026-06-03");
+  assert.equal(
+    notes,
+    "#### Added\n\n- A shiny new option.\n\n#### Fixed\n\n- A pesky bug.",
+  );
+});
+
+test("promote throws when there is no Unreleased section", () => {
+  const none = SAMPLE.replace("### [Unreleased]", "### [0.0.1] - (2020-01-01)");
+  assert.throws(
+    () => promote(none, "2.0.0", "2026-06-03"),
+    /No ### \[Unreleased\]/,
+  );
+});
+
+test("promote throws when the Unreleased section is empty", () => {
+  const empty = [
+    "## Change Log",
+    "",
+    "---",
+    "",
+    "### [Unreleased]",
+    "",
+    "---",
+    "",
+    "### [1.0.0] - (2020-01-01)",
+    "",
+    "- Initial",
+    "",
+  ].join("\n");
+  assert.throws(() => promote(empty, "2.0.0", "2026-06-03"), /empty/);
+});

--- a/scripts/promote-changelog.test.mjs
+++ b/scripts/promote-changelog.test.mjs
@@ -38,6 +38,31 @@ test("extractNotes returns null for a missing section", () => {
   assert.equal(extractNotes(SAMPLE, "9.9.9"), null);
 });
 
+test("extractNotes keeps a --- inside the body, dropping only the trailing one", () => {
+  const withRule = [
+    "### [Unreleased]",
+    "",
+    "#### Added",
+    "",
+    "- Before the rule.",
+    "",
+    "---",
+    "",
+    "- After the rule.",
+    "",
+    "---",
+    "",
+    "### [1.0.0] - (2020-01-01)",
+    "",
+    "- Initial",
+    "",
+  ].join("\n");
+  assert.equal(
+    extractNotes(withRule, "Unreleased"),
+    "#### Added\n\n- Before the rule.\n\n---\n\n- After the rule.",
+  );
+});
+
 test("promote moves Unreleased content under a dated version heading", () => {
   const { promoted } = promote(SAMPLE, "2.0.0", "2026-06-03");
   assert.match(promoted, /### \[2\.0\.0\] - \(2026-06-03\)/);

--- a/scripts/release-plan.mjs
+++ b/scripts/release-plan.mjs
@@ -1,0 +1,79 @@
+import { appendFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+// Next version for a major/minor/patch bump of an x.y.z version.
+export function nextVersion(current, bump) {
+  const [major, minor, patch] = current.split(".").map(Number);
+  if (bump === "major") return `${major + 1}.0.0`;
+  if (bump === "minor") return `${major}.${minor + 1}.0`;
+  if (bump === "patch") return `${major}.${minor}.${patch + 1}`;
+  throw new Error(`Unknown bump "${bump}" (expected major, minor, or patch)`);
+}
+
+// Numeric compare of two x.y.z versions: >0 if a>b, <0 if a<b, 0 if equal.
+function compare(a, b) {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+// Decide what a release run should do, from durable facts. Returns either
+// { mode, version } to proceed, or { mode, abort: true, message } to stop.
+export function resolvePlan({
+  current,
+  published,
+  bump,
+  tagExists,
+  headMatchesTag,
+  releaseComplete,
+}) {
+  if (compare(published, current) > 0) {
+    return {
+      mode: "orphan",
+      abort: true,
+      message: `Marketplace has v${published} but master is at v${current} with no v${published} tag. A prior release published without pushing its commit/tag; reconcile v${published} manually (push its commit + tag and create the Release) before re-running.`,
+    };
+  }
+  if (tagExists && !releaseComplete) {
+    if (!headMatchesTag) {
+      return {
+        mode: "finalize",
+        abort: true,
+        message: `Tag v${current} exists but its Release is missing or has no asset, and HEAD has moved past the tagged commit. Re-run from the tagged commit so the Release asset matches the published build, or reconcile manually.`,
+      };
+    }
+    return { mode: "finalize", version: current };
+  }
+  return { mode: "normal", version: nextVersion(current, bump) };
+}
+
+function main() {
+  const plan = resolvePlan({
+    current: process.env.CURRENT,
+    published: process.env.PUBLISHED,
+    bump: process.env.BUMP,
+    tagExists: process.env.TAG_EXISTS === "true",
+    headMatchesTag: process.env.HEAD_MATCHES_TAG === "true",
+    releaseComplete: process.env.RELEASE_COMPLETE === "true",
+  });
+  if (plan.abort) {
+    console.log(`::error::${plan.message}`);
+    process.exitCode = 1;
+    return;
+  }
+  const vsix = `terminal-all-in-one-${plan.version}.vsix`;
+  console.log(`${plan.mode} release: v${plan.version}`);
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    `version=${plan.version}\nvsix=${vsix}\nmode=${plan.mode}\n`,
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/release-plan.test.mjs
+++ b/scripts/release-plan.test.mjs
@@ -1,0 +1,95 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { nextVersion, resolvePlan } from "./release-plan.mjs";
+
+test("nextVersion bumps major/minor/patch", () => {
+  assert.equal(nextVersion("1.12.2", "major"), "2.0.0");
+  assert.equal(nextVersion("1.12.2", "minor"), "1.13.0");
+  assert.equal(nextVersion("1.12.2", "patch"), "1.12.3");
+});
+
+test("nextVersion throws on an unknown bump", () => {
+  assert.throws(() => nextVersion("1.0.0", "huge"), /bump/);
+});
+
+const base = {
+  current: "1.12.2",
+  published: "1.12.2",
+  bump: "major",
+  tagExists: false,
+  headMatchesTag: false,
+  releaseComplete: false,
+};
+
+test("normal release bumps from current when nothing is in flight", () => {
+  assert.deepEqual(resolvePlan(base), { mode: "normal", version: "2.0.0" });
+});
+
+test("normal release after a clean prior release (tag + complete release present)", () => {
+  const plan = resolvePlan({
+    ...base,
+    current: "2.0.0",
+    published: "2.0.0",
+    bump: "minor",
+    tagExists: true,
+    headMatchesTag: true,
+    releaseComplete: true,
+  });
+  assert.deepEqual(plan, { mode: "normal", version: "2.1.0" });
+});
+
+test("orphan (Marketplace ahead of master) aborts", () => {
+  const plan = resolvePlan({ ...base, current: "1.12.2", published: "2.0.0" });
+  assert.equal(plan.mode, "orphan");
+  assert.equal(plan.abort, true);
+  assert.match(plan.message, /2\.0\.0/);
+});
+
+test("finalize reuses the current version when its release is incomplete and HEAD matches the tag", () => {
+  const plan = resolvePlan({
+    ...base,
+    current: "2.0.0",
+    published: "2.0.0",
+    tagExists: true,
+    headMatchesTag: true,
+    releaseComplete: false,
+  });
+  assert.deepEqual(plan, { mode: "finalize", version: "2.0.0" });
+});
+
+test("finalize aborts when HEAD has moved past the tag", () => {
+  const plan = resolvePlan({
+    ...base,
+    current: "2.0.0",
+    published: "2.0.0",
+    tagExists: true,
+    headMatchesTag: false,
+    releaseComplete: false,
+  });
+  assert.equal(plan.mode, "finalize");
+  assert.equal(plan.abort, true);
+  assert.match(plan.message, /HEAD/);
+});
+
+test("a complete release for the current version is not re-finalized", () => {
+  const plan = resolvePlan({
+    ...base,
+    current: "2.0.0",
+    published: "2.0.0",
+    tagExists: true,
+    headMatchesTag: true,
+    releaseComplete: true,
+  });
+  assert.equal(plan.mode, "normal");
+});
+
+test("a lower published version is not treated as orphan", () => {
+  const plan = resolvePlan({
+    ...base,
+    current: "2.0.0",
+    published: "1.12.2",
+    bump: "patch",
+    tagExists: false,
+  });
+  assert.deepEqual(plan, { mode: "normal", version: "2.0.1" });
+});


### PR DESCRIPTION
Adds a one-button `workflow_dispatch` release pipeline (`.github/workflows/release.yml`) that gates, bumps the version, dates the `CHANGELOG`, publishes to the VS Code Marketplace, and cuts a GitHub Release — ordered to publish before any git write so a failed run (e.g. an expired token) recovers by simply re-running. Adds `scripts/promote-changelog.mjs` with `node:test` unit tests (also run on every PR via `integrate.yml`) to promote the changelog's `[Unreleased]` section and extract release notes. Reworks `package.json` scripts (adds `vscode:prepublish` and `test:scripts`, removes the manual `deploy`) and adds ignore rules so `scripts/`/`docs/` stay out of the packaged `.vsix`. Also trims the non-functional `cmd/ctrl+\`` keybinding row from the README and a stale link from the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added manual release workflow and CI steps for pre-publish, packaging and publish gating; added workflow linting and a dedicated script test runner; refined packaging ignore rules.

* **Documentation**
  * Removed the Toggle Terminal keybinding from the commands table and cleaned up changelog formatting.

* **Tests**
  * Added unit tests covering release planning and changelog promotion logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->