### PR TITLE
Pin GitHub Actions to commit SHAs, bump to Node 24 majors (#449, #451)

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -18,7 +18,7 @@ jobs:
     name: Greet First-Time Contributors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/first-interaction@v3
+      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
         with:
           issue_message: |
             👋 Thanks for opening your first issue on **Terminal All In One**! I appreciate you taking the time to help improve the extension.

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -21,13 +21,13 @@ jobs:
         node-version: [22.x]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,16 +29,16 @@ jobs:
       PUBLISHER: yasht
     steps:
       - name: Checkout master
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.x
           cache: pnpm
@@ -148,7 +148,7 @@ jobs:
 
       - name: Upload dry-run artifact
         if: ${{ inputs.dry_run }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.plan.outputs.vsix }}
           path: ${{ steps.plan.outputs.vsix }}


### PR DESCRIPTION
Pins every GitHub Action across `integrate.yml`, `release.yml`, and `greetings.yml` to a full-length immutable commit SHA (with a `# vX.Y.Z` comment) at its latest Node-24 major: checkout v6.0.3, pnpm/action-setup v6.0.8, setup-node v6.4.0, upload-artifact v7.0.1 (a safe v4→v7 jump — our `name`/`path` usage is unaffected), and first-interaction v3.1.0. This resolves the Node 20 runtime deprecation and the supply-chain pinning request in one pass. `greetings.yml` was outside the literal scope of both issues but is pinned here for consistency, since a leftover floating tag would defeat the goal of #451. Verified with the same `actionlint` image CI uses (`rhysd/actionlint:1.7.12`, exit 0) and confirmed no floating `@vN` tags remain.

Closes #449
Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build, test, and release workflows to use pinned dependency versions, enhancing the consistency and reliability of our continuous integration and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->