### PR TITLE
Exclude conductor.json from the published extension package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,6 +7,7 @@ eslint.config.mjs
 tsconfig.json
 pnpm-lock.yaml
 pnpm-workspace.yaml
+conductor.json
 
 # Extension
 src/


### PR DESCRIPTION
`conductor.json` is a Conductor workspace config tracked in git but, since it isn't a dotfile, the `.vscodeignore` `.*` rule never caught it — so it was shipping inside the published `.vsix` to all Marketplace users. This adds it to the Config ignore group so it's excluded from the package. Verified with `vsce ls`: the packaged file list is now just `package.json`, `README.md`, `LICENSE`, `CHANGELOG.md`, and `images/terminal-icon.jpg` (plus the built `dist/extension.js` on publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated extension packaging configuration to exclude certain files from distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->