### PR TITLE
Await terminal theme changes

### DIFF
--- a/src/commands/chooseTerminalTheme.ts
+++ b/src/commands/chooseTerminalTheme.ts
@@ -61,9 +61,10 @@ export async function chooseTerminalTheme() {
 }
 
 export function onTerminalThemeChange(event: ConfigurationChangeEvent) {
-  if (event.affectsConfiguration(`${EXTENSION_NAME}.${THEME_SECTION}`)) {
-    applyTheme(getConfig({ config: EXTENSION_NAME, section: THEME_SECTION }));
-  }
+  if (!event.affectsConfiguration(`${EXTENSION_NAME}.${THEME_SECTION}`)) return;
+  return applyTheme(
+    getConfig({ config: EXTENSION_NAME, section: THEME_SECTION }),
+  );
 }
 
 // Merge the theme's terminal colors onto the user's existing colorCustomizations, written at that setting's real scope. "None" strips terminal colors.

--- a/src/test/suite/chooseTerminalTheme.test.ts
+++ b/src/test/suite/chooseTerminalTheme.test.ts
@@ -65,15 +65,13 @@ suite("chooseTerminalTheme", () => {
     await theme.set(sample.name);
     await tick();
     await colors.set({});
-    onTerminalThemeChange({
+    await onTerminalThemeChange({
       affectsConfiguration: (s: string) => s === THEME,
     } as any);
-    await tick();
     assert.deepStrictEqual(colors.value(), { ...sample.colors });
 
     await colors.set({ "editor.background": "#123456" });
-    onTerminalThemeChange({ affectsConfiguration: () => false } as any);
-    await tick();
+    await onTerminalThemeChange({ affectsConfiguration: () => false } as any);
     assert.deepStrictEqual(colors.value(), { "editor.background": "#123456" });
   });
 


### PR DESCRIPTION
Update `onTerminalThemeChange` to return the promise from `applyTheme` and await it in the corresponding test. This removes timing-dependent ticks and ensures callers and tests observe completed theme writes. Validation: `pnpm run test:compile` and `pnpm run build:dev` passed; `pnpm test` reached VS Code startup but could not run because this workspace path produces an overlong macOS IPC socket path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal theme change handling so theme updates are applied only when the relevant setting changes.
  * Ensured theme updates complete reliably before the interface reflects the new colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->